### PR TITLE
Traffic data processing example

### DIFF
--- a/notebooks/ExtractTrafficData.ipynb
+++ b/notebooks/ExtractTrafficData.ipynb
@@ -1,0 +1,210 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import csv\n",
+    "import io\n",
+    "import os\n",
+    "import pickle\n",
+    "import uuid"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TRAFFIC_INFO_DIR = \"traffic_info_here\"\n",
+    "DT_FMT = \"%Y-%m-%d_%H:%M\"\n",
+    "LIMIT = 100\n",
+    "\n",
+    "fmap = {}\n",
+    "for i, entry in enumerate(os.scandir(TRAFFIC_INFO_DIR)):\n",
+    "    dt, ext = os.path.splitext(entry.name)\n",
+    "    if ext != '.pickle':\n",
+    "        continue\n",
+    "    fmap[dt] = entry.path\n",
+    "\n",
+    "traffic_info_dict = {}\n",
+    "dt_list = sorted(fmap)[:LIMIT]\n",
+    "for dt in dt_list:\n",
+    "    with io.open(fmap[dt], \"rb\") as f:\n",
+    "        traffic_info_dict[dt] = pickle.load(f)\n",
+    "\n",
+    "# for each timestamp there's a dict that maps node position codes to data records\n",
+    "nodes = set(traffic_info_dict[dt_list[0]])\n",
+    "assert all(set(_) == nodes for _ in traffic_info_dict.values())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "timestamp: 2019-02-21_12:33\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{7604: {'flux': 40.6,\n",
+       "  'length': 0.05632,\n",
+       "  'conf': 0.85,\n",
+       "  'jam': 1.3075,\n",
+       "  'speed': (35.96, 35.96),\n",
+       "  'loc': 'Cagliari',\n",
+       "  'date': '2019-02-21T11:32:05Z',\n",
+       "  'coord': (39.23172, 9.13497),\n",
+       "  'osm_edge': 1521099731},\n",
+       " 7605: {'flux': 45.4,\n",
+       "  'length': 5.2647,\n",
+       "  'conf': 0.89,\n",
+       "  'jam': 2.39552,\n",
+       "  'speed': (32.89, 32.89),\n",
+       "  'loc': 'Quartu S.Elena',\n",
+       "  'date': '2019-02-21T11:32:05Z',\n",
+       "  'coord': (39.24437, 9.18942),\n",
+       "  'osm_edge': 265653413}}"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "date_time = dt_list[0]\n",
+    "print(f\"timestamp: {date_time}\")\n",
+    "d = traffic_info_dict[dt_list[0]]\n",
+    "{k: v for k, v in sorted(d.items())[:2]}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def extract_nodes(traffic_info):\n",
+    "    nodes = {}\n",
+    "    for t, v in traffic_info.items():\n",
+    "        for pc, data in v.items():\n",
+    "            if pc not in nodes:\n",
+    "                crd = data['coord']\n",
+    "                nodes[pc] = {\n",
+    "                    'uuid': str(uuid.uuid4()),\n",
+    "                    'osm_edge': data['osm_edge'], 'lon': crd[1], 'lat': crd[0]}\n",
+    "    return nodes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nodes = extract_nodes(traffic_info_dict)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def define_sensors(nodes):\n",
+    "    sensors = {}\n",
+    "    for pc, d in nodes.items():\n",
+    "        for t in ['jam', 'speed', 'flux', 'length']:\n",
+    "            sensors[(pc, t)] = {'uuid': str(uuid.uuid4()), 'lon': d['lon'], \n",
+    "                                'lat': d['lat'],\n",
+    "                                'type': t, 'node': d['uuid']}\n",
+    "    return sensors\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sensors = define_sensors(nodes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def dump_nodes(nodes, fname):\n",
+    "    with io.open(fname, 'w') as f:\n",
+    "        w = csv.DictWriter(f, fieldnames=['uuid', 'osm_edge', 'lon', 'lat'])\n",
+    "        w.writeheader()\n",
+    "        for pc, d in nodes.items():\n",
+    "            w.writerow(d)\n",
+    "            \n",
+    "def dump_sensors(sensors, fname):\n",
+    "    with io.open(fname, 'w') as f:\n",
+    "        w = csv.DictWriter(f, fieldnames=['uuid', 'type', 'node', 'lon', 'lat'])\n",
+    "        w.writeheader()\n",
+    "        for pc, d in sensors.items():\n",
+    "            w.writerow(d)\n",
+    "\n",
+    "def dump_measures(sensors, traffic, fname):\n",
+    "    with io.open(fname, 'w') as f:\n",
+    "        w = csv.DictWriter(f, fieldnames=['uuid', 'time', 'measure'])\n",
+    "        w.writeheader()\n",
+    "        for t, v in traffic.items():\n",
+    "            for pc, data in v.items():\n",
+    "                for t in ['jam', 'speed', 'flux', 'length']:\n",
+    "                    w.writerow({\n",
+    "                            'uuid': sensors[(pc, t)]['uuid'],\n",
+    "                            'time': data['date'],\n",
+    "                            'measure': data[t][0] if t == 'speed' else data[t]\n",
+    "                            })"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dump_nodes(nodes, 'nodes.csv')\n",
+    "dump_sensors(sensors, 'sensors.csv')\n",
+    "dump_measures(sensors, traffic_info_dict, 'measures.csv')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/scripts/here/HERE_JSON_extractor.py
+++ b/scripts/here/HERE_JSON_extractor.py
@@ -159,20 +159,18 @@ def load_save_osm_map(place_name):
 
 verbose = False
 processed_path = "./processed/"
-try:
-    os.makedirs(processed_path)
-except FileExistsError:
-    pass
+traffic_info_dir = "./traffic_info_here"
+for p in processed_path, traffic_info_dir:
+    try:
+        os.makedirs(p)
+    except FileExistsError:
+        pass
 
 G = load_save_osm_map("Sardinia")
 
 
-try:
-    traffic_info_dict = load_from_file("traffic_info_here.pickle")
-    print("Loaded Traffic Info file...")
-except:
-    traffic_info_dict = {}
-    
+processed_dts = set(os.path.splitext(_.name)[0]
+                    for _ in os.scandir(traffic_info_dir))
 try:
     location_dict = load_from_file("location_id_here_updated.pickle")
     print ("LOADED location_id file...")
@@ -189,20 +187,16 @@ for i, name in enumerate(glob.glob('*.json')):
         continue
     date_time = name[13:-5]
     print(date_time) 
-    if date_time in traffic_info_dict:
+    if date_time in processed_dts:
         print("SKIPPED, ALREADY PRESENT...")
         continue
     rws = load_json(name)
-    traffic_info_dict[date_time], location_dict, osm_edges_dict = extract_traffic_data(rws, location_dict, osm_edges_dict)
-    
+    traffic_data, location_dict, osm_edges_dict = extract_traffic_data(rws, location_dict, osm_edges_dict)
+    traffic_out_fn = os.path.join(traffic_info_dir, f"{date_time}.pickle")
+    with open(traffic_out_fn, "wb") as f:
+        pickle.dump(traffic_data, f)
     shutil.move(name, processed_path+name)
 
 #optionally save the updated location dictionary to file
 pickle.dump(location_dict, open("location_id_here_updated.pickle", "wb"))
 pickle.dump(osm_edges_dict, open("osm_edges_here_updated.pickle", "wb"))
-
-pickle.dump(traffic_info_dict, open("traffic_info_here.pickle", "wb"))
-
-
-
-


### PR DESCRIPTION
Changes the script that gets the data from the original downloads to store a separate traffic info item for each timestamp (to avoid generating a huge file). Adds a notebook with an example on how to read the data produced by the script.