### PR TITLE
adds requests dependency in tdmqc docker image

### DIFF
--- a/docker/Dockerfile.tdmqc
+++ b/docker/Dockerfile.tdmqc
@@ -67,6 +67,6 @@ COPY core-site.xml /opt/hadoop/etc/hadoop/core-site.xml
 COPY ./tdmq-dist /tdmq-dist
 WORKDIR /tdmq-dist
 
-RUN pip3 install --no-cache-dir pytest && \
+RUN pip3 install --no-cache-dir requests pytest && \
     python3 setup.py install
 ENTRYPOINT ["/bin/bash", "-l", "-c", "pytest ./tests"]


### PR DESCRIPTION
this PR adds the installation of the python module requests in tdmqc docker image. This is a temporary fix, the dependency should be set in setup.py, which should be refactored in order to install individually the server or the client.