### PR TITLE
Run jupyter notebook as any user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,18 @@ images:
 	docker build -f docker/Dockerfile.jupyter -t tdm/tdmqj docker
 	docker build -f docker/Dockerfile.web -t tdm/web docker
 
-
-run: images
+docker/docker-compose.yml: docker/docker-compose.yml-tmpl
 	sed -e "s^LOCAL_PATH^$${PWD}^" -e "s^USER_UID^$$(id -u)^" \
             -e "s^USER_GID^$$(id -g)^"  \
             < docker/docker-compose.yml-tmpl > docker/docker-compose.yml
+
+run: images docker/docker-compose.yml
 	docker-compose -f ./docker/docker-compose.yml up
 
-clean:
+start: images docker/docker-compose.yml
+	docker-compose -f ./docker/docker-compose.yml up -d
+
+stop:
 	docker-compose -f ./docker/docker-compose.yml down
 
+clean: stop

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+
+
+
+Run the `TDMQ_API_Experiments.ipynb` notebook first to initialize the database
+and load some data.

--- a/docker/Dockerfile.jupyter
+++ b/docker/Dockerfile.jupyter
@@ -33,6 +33,7 @@ COPY core-site.xml /opt/hadoop/etc/hadoop/core-site.xml
 RUN cd /tdmq-dist \
  && find . -type f -print0 | xargs -0 chmod a+r \
  && find . -type d -print0 | xargs -0 chmod a+rx \
+ && chmod 644 /opt/hadoop/etc/hadoop/core-site.xml \
  && python3 setup.py install
 
 COPY tdmqj-entrypoint.sh /usr/local/bin/

--- a/docker/Dockerfile.jupyter
+++ b/docker/Dockerfile.jupyter
@@ -1,22 +1,22 @@
 FROM tdm/tdmqc
 
-#FROM hd311
-# LABEL maintainer="gianluigi.zanetti@crs4.it"
+RUN apt-get update -q \
+ && apt-get install -y --no-install-recommends libnss-wrapper \
+ && apt-get autoclean && apt-get clean
 
 RUN useradd -m jupyter && \
     pip3 install --no-cache-dir \
         ckanapi \
-	folium \
+        folium \
         jupyter \
         matplotlib \
         cartopy \
-	colormap \
+        colormap \
         easydev \
-	psycopg2 \
-	pyproj \
+        psycopg2 \
+        pyproj \
         xarray \
         wget
-	
 
 RUN CLASSPATH=`/opt/hadoop/bin/hadoop classpath --glob` && \
     echo "export CLASSPATH=\"${CLASSPATH}\"" >> /etc/profile.d/hadoop.sh && \
@@ -30,17 +30,27 @@ ENV HADOOP_LOG_DIR="/home/jupyter/hadoop_logs"
 
 COPY core-site.xml /opt/hadoop/etc/hadoop/core-site.xml
 
-COPY ./tdmq-dist /tdmq-dist
-WORKDIR /tdmq-dist
+RUN cd /tdmq-dist \
+ && find . -type f -print0 | xargs -0 chmod a+r \
+ && find . -type d -print0 | xargs -0 chmod a+rx \
+ && python3 setup.py install
 
-RUN python3 setup.py install
+COPY tdmqj-entrypoint.sh /usr/local/bin/
+RUN chmod 755 /usr/local/bin/tdmqj-entrypoint.sh
+ENTRYPOINT [ "/usr/local/bin/tdmqj-entrypoint.sh" ]
 
-WORKDIR /home/jupyter
+
 USER jupyter
-RUN mkdir .jupyter notebooks
-COPY --chown=jupyter jupyter_notebook_config.py .jupyter/
+
+ENV HOME=/home/jupyter
+ENV TDMQ_DIST=/tdmq-dist
+ENV DATA_DIR="${TDMQ_DIST}/data"
+
+RUN mkdir --parents /home/jupyter/.jupyter /home/jupyter/notebooks \
+ && find /home/jupyter/ -type f -print0 | xargs -0 chmod a+rw \
+ && find /home/jupyter/ -type d -print0 | xargs -0 chmod a+rwx
 
 WORKDIR notebooks
+CMD [ "--notebook-dir=/home/jupyter/notebooks" ]
 
 EXPOSE 8888
-ENTRYPOINT ["/bin/bash", "-l", "-c", "jupyter notebook"]

--- a/docker/Dockerfile.jupyter
+++ b/docker/Dockerfile.jupyter
@@ -16,6 +16,7 @@ RUN useradd -m jupyter && \
         psycopg2 \
         pyproj \
         xarray \
+        tifffile \
         wget
 
 RUN CLASSPATH=`/opt/hadoop/bin/hadoop classpath --glob` && \

--- a/docker/Dockerfile.tdmqc
+++ b/docker/Dockerfile.tdmqc
@@ -22,6 +22,7 @@ RUN echo 'APT::Get::Assume-Yes "true";' >> /etc/apt/apt.conf.d/99yes && \
       python3-dev \
       python3-pip \
       python3-gdal \
+      python3-numpy \
       wget && \
     apt-get clean
 

--- a/docker/jupyter_notebook_config.py
+++ b/docker/jupyter_notebook_config.py
@@ -1,4 +1,0 @@
-# flake8: noqa
-
-c.NotebookApp.ip = '0.0.0.0'
-c.NotebookApp.open_browser = False

--- a/docker/tdmqj-entrypoint.sh
+++ b/docker/tdmqj-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -l
+
+# Make the current UID:GID look like the `jupyter` user
+if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
+  export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
+  export NSS_WRAPPER_PASSWD="$(mktemp)"
+  export NSS_WRAPPER_GROUP="$(mktemp)"
+  echo "jupyter:x:$(id -u):$(id -g):Jupyter:$HOME:/bin/false" > "$NSS_WRAPPER_PASSWD"
+  echo "jupyter:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
+fi
+
+jupyter notebook --ip=0.0.0.0 --port=8888 --no-browser "${@}"

--- a/notebooks/TDMQ_API_Experiments.ipynb
+++ b/notebooks/TDMQ_API_Experiments.ipynb
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,11 +29,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
-    "BASE_URL = 'http://localhost:8000/api/v0.0'"
+    "BASE_URL = 'http://web:8000/api/v0.0'"
    ]
   },
   {
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -89,7 +89,7 @@
        "  'type': 'power sensor'}]"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -126,7 +126,7 @@
        "  'type': 'multisensor'}]"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -138,7 +138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -155,7 +155,7 @@
        "  'type': 'TemperatureSensorDTH11'}]"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -167,7 +167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 10,
    "metadata": {
     "scrolled": true
    },
@@ -186,7 +186,7 @@
        "  'type': 'multisensor'}]"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -205,7 +205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -243,7 +243,7 @@
        "  'type': 'sensor_type_1'}]"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -254,7 +254,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -267,7 +267,7 @@
        " 'type': 'sensor_type_0'}"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -286,7 +286,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -304,7 +304,7 @@
        "  'type': 'sensor_type_0'}]"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -323,7 +323,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -341,7 +341,7 @@
        "  'type': 'sensor_type_1'}]"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -357,7 +357,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -366,7 +366,7 @@
        "[]"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -389,7 +389,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -400,7 +400,7 @@
        " 'timedelta': [0.0, 5.0, 10.0, 15.0, 20.0, 25.0]}"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -415,7 +415,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -426,7 +426,7 @@
        " 'timedelta': [0.0, 10.0, 20.0]}"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -443,7 +443,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -454,7 +454,7 @@
        " 'timedelta': [0.0, 4.8, 9.9, 15.0, 19.8, 24.9]}"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -468,6 +468,34 @@
     "}\n",
     "requests.get(f'{BASE_URL}/sensors/{code}/timeseries', params=args).json()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/api_load.ipynb
+++ b/notebooks/api_load.ipynb
@@ -31,8 +31,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "BASE_URL = \"http://localhost:8000/api/v0.0\"\n",
-    "data_dir = \"../tests/data\""
+    "BASE_URL = \"http://web:8000/api/v0.0\"\n",
+    "data_dir = os.getenv(\"DATA_DIR\")"
    ]
   },
   {
@@ -44,19 +44,47 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['c7afa96b-ca9a-5561-b57b-5187ad005d75',\n",
-       " '542c74cb-abcc-503e-abc6-d818284551f4',\n",
-       " '7b8f71df-4517-5ffc-b627-f4b37a49b925',\n",
-       " '1d48a1f4-9440-5965-8b2d-809bf529d851']"
+       "[{'type': 'TemperatureSensorDTH11',\n",
+       "  'name': 'sensor_type_0',\n",
+       "  'brandName': 'Acme',\n",
+       "  'modelName': 'Acme multisensor DHT11',\n",
+       "  'manufacturerName': 'Acme Inc.',\n",
+       "  'category': ['sensor'],\n",
+       "  'function': ['sensing'],\n",
+       "  'controlledProperty': ['temperature']},\n",
+       " {'type': 'HumiditySensorDHT11',\n",
+       "  'name': 'sensor_type_1',\n",
+       "  'brandName': 'Acme',\n",
+       "  'modelName': 'Acme multisensor DHT11',\n",
+       "  'manufacturerName': 'Acme Inc.',\n",
+       "  'category': ['sensor'],\n",
+       "  'function': ['sensing'],\n",
+       "  'controlledProperty': ['humidity']},\n",
+       " {'type': 'multisensor',\n",
+       "  'name': 'sensor_type_2',\n",
+       "  'brandName': 'ProSensor',\n",
+       "  'modelName': 'R2D2',\n",
+       "  'manufacturerName': 'CRS4',\n",
+       "  'category': ['sensor'],\n",
+       "  'function': ['sensing'],\n",
+       "  'controlledProperty': ['humidity', 'temperature']},\n",
+       " {'type': 'power sensor',\n",
+       "  'name': 'sensor_type_3',\n",
+       "  'brandName': 'ProSensor',\n",
+       "  'modelName': 'C3PO',\n",
+       "  'manufacturerName': 'CRS4',\n",
+       "  'category': ['sensor'],\n",
+       "  'function': ['sensing'],\n",
+       "  'controlledProperty': ['power']}]"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -64,7 +92,31 @@
    "source": [
     "with open(os.path.join(data_dir, \"sensor_types.json\")) as f:\n",
     "    data = json.load(f)[\"sensor_types\"]\n",
-    "codes = requests.post(f'{BASE_URL}/sensor_types', json=data).json()\n",
+    "data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "HTTPError",
+     "evalue": "500 Server Error: INTERNAL SERVER ERROR for url: http://web:8000/api/v0.0/sensor_types",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mHTTPError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-5-60efff48dd8d>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0mresponse\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mrequests\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpost\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mf'{BASE_URL}/sensor_types'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mjson\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mresponse\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mraise_for_status\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mcodes\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mresponse\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mjson\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0mcodes\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/usr/local/lib/python3.6/dist-packages/requests/models.py\u001b[0m in \u001b[0;36mraise_for_status\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    938\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    939\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mhttp_error_msg\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 940\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mHTTPError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mhttp_error_msg\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mresponse\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    941\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    942\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mclose\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mHTTPError\u001b[0m: 500 Server Error: INTERNAL SERVER ERROR for url: http://web:8000/api/v0.0/sensor_types"
+     ]
+    }
+   ],
+   "source": [
+    "response = requests.post(f'{BASE_URL}/sensor_types', json=data)\n",
+    "response.raise_for_status()\n",
+    "codes = response.json()\n",
     "codes"
    ]
   },
@@ -109,7 +161,9 @@
    "source": [
     "with open(os.path.join(data_dir, \"sensors.json\")) as f:\n",
     "    data = json.load(f)[\"sensors\"]\n",
-    "codes = requests.post(f'{BASE_URL}/sensors', json=data).json()\n",
+    "response = requests.post(f'{BASE_URL}/sensors', json=data)\n",
+    "response.raise_for_status()\n",
+    "codes = response.json()\n",
     "codes"
    ]
   },
@@ -148,7 +202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -157,7 +211,7 @@
        "{'loaded': 21}"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -165,23 +219,83 @@
    "source": [
     "with open(os.path.join(data_dir, \"measures.json\")) as f:\n",
     "    data = json.load(f)[\"measures\"]\n",
-    "requests.post(f'{BASE_URL}/measures', json=data).json()"
+    "response = requests.post(f'{BASE_URL}/measures', json=data)\n",
+    "response.raise_for_status()\n",
+    "response.json()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'data': [0.022, 0.122, 0.222, 0.322, 0.422, 0.522],\n",
+       "{'data': [0.022,\n",
+       "  0.122,\n",
+       "  0.222,\n",
+       "  0.322,\n",
+       "  0.422,\n",
+       "  0.522,\n",
+       "  0.022,\n",
+       "  0.122,\n",
+       "  0.222,\n",
+       "  0.322,\n",
+       "  0.422,\n",
+       "  0.522,\n",
+       "  0.022,\n",
+       "  0.122,\n",
+       "  0.222,\n",
+       "  0.322,\n",
+       "  0.422,\n",
+       "  0.522,\n",
+       "  0.022,\n",
+       "  0.122,\n",
+       "  0.222,\n",
+       "  0.322,\n",
+       "  0.422,\n",
+       "  0.522,\n",
+       "  0.022,\n",
+       "  0.122,\n",
+       "  0.222,\n",
+       "  0.322,\n",
+       "  0.422,\n",
+       "  0.522],\n",
        " 'timebase': '2019-05-02T11:00:00Z',\n",
-       " 'timedelta': [0.0, 5.0, 10.0, 15.0, 20.0, 25.0]}"
+       " 'timedelta': [0.0,\n",
+       "  5.0,\n",
+       "  10.0,\n",
+       "  15.0,\n",
+       "  20.0,\n",
+       "  25.0,\n",
+       "  0.0,\n",
+       "  5.0,\n",
+       "  10.0,\n",
+       "  15.0,\n",
+       "  20.0,\n",
+       "  25.0,\n",
+       "  0.0,\n",
+       "  5.0,\n",
+       "  10.0,\n",
+       "  15.0,\n",
+       "  20.0,\n",
+       "  25.0,\n",
+       "  0.0,\n",
+       "  5.0,\n",
+       "  10.0,\n",
+       "  15.0,\n",
+       "  20.0,\n",
+       "  25.0,\n",
+       "  0.0,\n",
+       "  5.0,\n",
+       "  10.0,\n",
+       "  15.0,\n",
+       "  20.0,\n",
+       "  25.0]}"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
This PR makes changes to the Jupyter notebook image so that it can run as any user (I suspect that all testers thus far had uid 1000).

There are also some small changes to the notebooks to use the docker-compose service names instead of localhost and a minimal README that suggests running the TDMQ_API_Experiments.ipynb before anything else.

Some notebooks don't run (e.g., ClientInterface), but I suspect they didn't before either.