### PR TITLE
Speed-up partial rebuilds

### DIFF
--- a/docker/Dockerfile.jupyter
+++ b/docker/Dockerfile.jupyter
@@ -1,4 +1,4 @@
-FROM tdmproject/tdmqc
+FROM tdmproject/tdmqc-deps
 
 RUN apt-get update -q \
  && apt-get install -y --no-install-recommends libnss-wrapper libproj-dev proj-data proj-bin libgeos-dev \
@@ -7,7 +7,7 @@ RUN apt-get update -q \
 RUN useradd -m jupyter && \
     pip3 install --no-cache-dir \
         ckanapi \
-    	folium \
+        folium \
         jupyter \
         matplotlib \
         cython \
@@ -31,6 +31,7 @@ RUN echo "export HADOOP_HOME=/opt/hadoop" >> /etc/profile.d/hadoop.sh && \
 ENV HADOOP_LOG_DIR="/home/jupyter/hadoop_logs"
 
 
+COPY ./tdmq-dist /tdmq-dist
 RUN cd /tdmq-dist \
  && find . -type f -print0 | xargs -0 chmod a+r \
  && find . -type d -print0 | xargs -0 chmod a+rx \

--- a/docker/Dockerfile.tdmqc
+++ b/docker/Dockerfile.tdmqc
@@ -1,10 +1,12 @@
-FROM tdmproject/tiledb:0.1.1
+FROM tdmproject/tiledb:0.1.1 AS deps
 
-#FROM hd311
+RUN pip3 install --no-cache-dir requests pytest  flask click psycopg2-binary
+
+
+FROM deps
 
 COPY ./tdmq-dist /tdmq-dist
 WORKDIR /tdmq-dist
+RUN python3 setup.py install
 
-RUN pip3 install --no-cache-dir requests pytest && \
-    python3 setup.py install
 CMD ["tail", "-f", "/dev/null"]

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -1,11 +1,15 @@
 FROM python:3.7
+
+RUN pip install --upgrade pip && \
+  pip install flask gunicorn pytest sphinx sphinxcontrib-httpdomain
+
 COPY ./tdmq-dist /tdmq-dist
 COPY web-entrypoint.sh /
 WORKDIR /tdmq-dist
-RUN chmod +x /web-entrypoint.sh
-RUN pip install --upgrade pip && \
-  pip install flask gunicorn pytest sphinx sphinxcontrib-httpdomain && \
-  pip install -e .
+
+RUN chmod +x /web-entrypoint.sh \
+ && pip install -e .
+
 EXPOSE 8000
 WORKDIR /tdmq-dist/tdmq
 CMD /web-entrypoint.sh

--- a/docker/docker-compose.yml-tmpl
+++ b/docker/docker-compose.yml-tmpl
@@ -3,7 +3,7 @@ version: "3"
 services:
 
   timescaledb:
-    image: timescale/timescaledb-postgis
+    image: timescale/timescaledb-postgis:1.4.0-pg11
     ports:
       - "5432"
     environment:


### PR DESCRIPTION
This PR tries to speed-up image rebuilds for this repository.

It brings code from the project closer to the last layers of the images, which reduces the number of layers that are rebuilt when code changes.  This is in part done by creating a `tdmqc-deps` image, which is then used by both the jupyter and the tdmqc image.  It's also done by pre-installing known dependencies (e.g., for the `web` image) so that when the real installation phase is run it finds that packages are already present.

Finally, more of the dependencies between things are described in the Makefile so that `make` can eliminate steps when possible.  Also, this brought me to write individual rules for each image so that now you can, for instance, rebuild the `web` image with `make web`.