### PR TITLE
New docker-compose development mode for flask app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
+
+
 PSWD=foobar
-#IMAGE=timescale/timescaledb
-IMAGE=timescale/timescaledb-postgis
 
 all: images
 
@@ -23,13 +23,29 @@ web: docker/tdmq-dist docker/Dockerfile.web
 
 images: tdmqc jupyter web
 
+docker/docker-compose-dev.yml: docker/docker-compose.yml-tmpl
+	sed -e "s^LOCAL_PATH^$${PWD}^" \
+	    -e "s^USER_UID^$$(id -u)^" \
+	    -e "s^USER_GID^$$(id -g)^" \
+	    -e "s^DEV=false^DEV=true^" \
+	    -e "s^#DEV *^^" \
+	       < docker/docker-compose.yml-tmpl > docker/docker-compose-dev.yml
+
+
 docker/docker-compose.yml: docker/docker-compose.yml-tmpl
-	sed -e "s^LOCAL_PATH^$${PWD}^" -e "s^USER_UID^$$(id -u)^" \
-            -e "s^USER_GID^$$(id -g)^"  \
-            < docker/docker-compose.yml-tmpl > docker/docker-compose.yml
+	sed -e "s^LOCAL_PATH^$${PWD}^" \
+	    -e "s^USER_UID^$$(id -u)^" \
+	    -e "s^USER_GID^$$(id -g)^" \
+	     < docker/docker-compose.yml-tmpl > docker/docker-compose.yml
 
 run: images docker/docker-compose.yml
 	docker-compose -f ./docker/docker-compose.yml up
+
+startdev: images docker/docker-compose-dev.yml
+	docker-compose -f ./docker/docker-compose-dev.yml up -d
+
+stopdev:
+	docker-compose -f ./docker/docker-compose-dev.yml down
 
 start: images docker/docker-compose.yml
 	docker-compose -f ./docker/docker-compose.yml up -d
@@ -40,4 +56,4 @@ stop:
 clean: stop
 
 
-.PHONY: all tdmqc-deps tdmqc jupyter web images run start stop clean
+.PHONY: all tdmqc-deps tdmqc jupyter web images run start stop startdev stopdev clean

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -3,13 +3,16 @@ FROM python:3.7
 RUN pip install --upgrade pip && \
   pip install flask gunicorn pytest sphinx sphinxcontrib-httpdomain
 
-COPY ./tdmq-dist /tdmq-dist
-COPY web-entrypoint.sh /
-WORKDIR /tdmq-dist
+EXPOSE 8000
+CMD /web-entrypoint.sh
 
-RUN chmod +x /web-entrypoint.sh \
+COPY --chown=root ./tdmq-dist /tdmq-dist
+COPY --chown=root web-entrypoint.sh /
+
+RUN chmod a+rx /web-entrypoint.sh \
+ && cd /tdmq-dist \
+ && find . -type f -print0 | xargs -0 chmod a+r \
+ && find . -type d -print0 | xargs -0 chmod a+rx \
  && pip install -e .
 
-EXPOSE 8000
 WORKDIR /tdmq-dist/tdmq
-CMD /web-entrypoint.sh

--- a/docker/docker-compose.yml-tmpl
+++ b/docker/docker-compose.yml-tmpl
@@ -25,8 +25,13 @@ services:
       - "timescaledb"
     ports:
       - "8000:8000"
+    #DEV user: USER_UID:USER_GID
     environment:
     - "CREATE_DB=true"
+    - "DEV=false"
+    #DEV volumes:
+    #DEV - "LOCAL_PATH/tdmq:/tdmq-dist/tdmq"
+
   namenode:
     image: crs4/namenode:3.2.0
     ports:

--- a/docker/web-entrypoint.sh
+++ b/docker/web-entrypoint.sh
@@ -23,4 +23,15 @@ if [[ "$CREATE_DB" == "true" ]]; then
   create_db
 fi
 
-gunicorn -b 0.0.0.0:8000 wsgi:app
+if [[ "${DEV}" == "true" ]]; then
+    printf "DEV is ${DEV}. Starting container in development mode\n" >&2
+    printf "Do not run this configuration in production!\n" >&2
+    set -x
+    export FLASK_APP=/tdmq-dist/tdmq/wsgi
+    export FLASK_ENV=development
+    export FLASK_RUN_PORT=8000 # by default in dev mode it changes its port to 5000
+    export FLASK_RUN_HOST=0.0.0.0
+    flask run "${@}"
+else
+    gunicorn -b 0.0.0.0:8000 wsgi:app
+fi


### PR DESCRIPTION
Start docker-compose with `make startdev` instead of `make start`.  Flask will be started in development mode.  Among other things, auto-reload is enabled and your local `tdmq` directory will be mounted in the container.  This means that any local change to the code will be almost immediately be picked up by the running web service.