### PR TITLE
Changes response code when the client tries to create a source already created

### DIFF
--- a/tdmq/api.py
+++ b/tdmq/api.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 class DuplicateItemException(werkzeug.exceptions.HTTPException):
-    code = 512
+    code = 409
     description = 'Attempt to duplicate unique field.'
 
 

--- a/tdmq/app.py
+++ b/tdmq/app.py
@@ -2,11 +2,12 @@
 
 import logging
 import os
-import flask
 
+import flask
+from flask.json import jsonify
+
+from tdmq.api import DuplicateItemException, add_routes
 from tdmq.db import add_db_cli, close_db
-from tdmq.api import add_routes
-from tdmq.api import DuplicateItemException
 
 
 def configure_logging(app):
@@ -61,7 +62,7 @@ def create_app(test_config=None):
     @app.errorhandler(DuplicateItemException)
     def handle_duplicate(e):
         app.logger.error('duplicate item exception %s', e.args)
-        return f'{e.args}', 512
+        return jsonify({"error": "duplicated_source_id"}), e.code
 
     @app.teardown_appcontext
     def teardown_db(arg):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -82,6 +82,28 @@ def _validate_ids(data, expected):
     assert set( s['external_id'] for s in data ) == expected
 
 
+def test_source_create_duplicate(flask_client, app, db_data, source_data):
+    source_data = [{
+        "id": "st1",
+        "alias": "st1",
+        "entity_type": "WeatherObserver",
+        "entity_category": "Station",
+        "default_footprint": {
+            "type": "Point",
+            "coordinates": [1.1, 2.2]
+        },
+        "stationary": True,
+        "controlledProperties": ["windDirection", "windSpeed"],
+        "shape": [],
+        "description": {}
+    }]
+    response = flask_client.post('/sources', json=source_data)
+    _checkresp(response)
+    response = flask_client.post('/sources', json=source_data)
+    assert response.status == '409 CONFLICT'
+    assert response.get_json() == {"error": "duplicated_source_id"}
+
+
 def test_sources_no_args(flask_client, app, db_data, source_data):
     response = flask_client.get('/sources')
     _checkresp(response)


### PR DESCRIPTION
When a REST client tries to create a source performing a POST, and the source already exists the server returns 512. 
I think "409 - Conflict" should be more appropriate. 

https://www.restapitutorial.com/httpstatuscodes.html states that 409 is used when 

> The request could not be completed due to a conflict with the current state of the resource. This code is only allowed in situations where it is expected that the user might be able to resolve the conflict and resubmit the request

I think it applies to our case, since the state of the resource is "Already existent". I changed the response also to return  a json that explain the problem