### PR TITLE
Refactor routes

### DIFF
--- a/tdmq/api.py
+++ b/tdmq/api.py
@@ -3,16 +3,15 @@ import sys
 from datetime import timedelta
 
 import werkzeug.exceptions as wex
-from flask import jsonify, request, url_for
-from prometheus_client.registry import REGISTRY
-from prometheus_client.utils import INF
-from prometheus_client.metrics import Histogram, Summary
+from flask import Blueprint, current_app, jsonify, request, url_for
 
 import tdmq.db as db
 import tdmq.errors
 from tdmq.utils import convert_roi
 
 logger = logging.getLogger(__name__)
+
+tdmq_bp = Blueprint('tdmq', __name__)
 
 
 def _restructure_timeseries(res, properties):
@@ -25,291 +24,285 @@ def _restructure_timeseries(res, properties):
     return result
 
 
-def add_routes(app, registry=REGISTRY):
-    http_request_prom = Histogram('tdmq_http_requests_seconds', 'Elapsed time to process http requests',
-                                  ['method', 'endpoint'], buckets=[.5, 1, 5, 10, 20, INF], registry=registry)
-    http_response_prom = Histogram('tdmq_http_response_bytes', 'Size in bytes of an http response',
-                                   ['method', 'endpoint'], buckets=[1, 2, 5, 10, 20, INF], registry=registry)
+@tdmq_bp.before_request
+def print_args():
+    logger.debug("request.args: %s", request.args)
 
-    @app.before_request
-    def print_args():
-        logger.debug("request.args: %s", request.args)
+@tdmq_bp.route('/')
+def index():
+    return 'The URL for this page is {}'.format(url_for('tdmq.index'))
 
-    @app.route('/')
-    def index():
-        return 'The URL for this page is {}'.format(url_for('index'))
+@tdmq_bp.route('/entity_types')
+def entity_types():
+    with current_app.http_request_prom.labels(method='get', endpoint='entity_types').time():
+        types = db.list_entity_types()
+        res = jsonify({'entity_types': types})
+        current_app.http_response_prom.labels(method='get', endpoint='entity_types').observe(
+            sys.getsizeof(res.data))
+        return res
 
-    @app.route('/entity_types')
-    def entity_types():
-        with http_request_prom.labels(method='get', endpoint='entity_types').time():
-            types = db.list_entity_types()
-            res = jsonify({'entity_types': types})
-            http_response_prom.labels(method='get', endpoint='entity_types').observe(
-                    sys.getsizeof(res.data))
-            return res
+@tdmq_bp.route('/entity_categories')
+def entity_categories():
+    with current_app.http_request_prom.labels(method='get', endpoint='entity_categories').time():
+        categories = db.list_entity_categories()
+        res = jsonify({'entity_categories': categories})
+        current_app.http_response_prom.labels(method='get', endpoint='entity_categories').observe(
+            sys.getsizeof(res.data))
+        return res
 
-    @app.route('/entity_categories')
-    def entity_categories():
-        with http_request_prom.labels(method='get', endpoint='entity_categories').time():
-            categories = db.list_entity_categories()
-            res = jsonify({'entity_categories': categories})
-            http_response_prom.labels(method='get', endpoint='entity_categories').observe(
-                    sys.getsizeof(res.data))
-            return res
+@tdmq_bp.route('/sources', methods=['GET', 'POST'])
+def sources():
+    """Return a list of sources.
 
-    @app.route('/sources', methods=['GET', 'POST'])
-    def sources():
-        """Return a list of sources.
+    .. :quickref: Get sources
 
-        .. :quickref: Get sources
+    With no parameters, return all sources. When ``roi``,
+    ``after`` and ``before`` are specified, return all sources
+    that have reported an event that intesect the corresponding
+    spatio-temporal region. It is
+    also possible to filter by any of the following:
 
-        With no parameters, return all sources. When ``roi``,
-        ``after`` and ``before`` are specified, return all sources
-        that have reported an event that intesect the corresponding
-        spatio-temporal region. It is
-        also possible to filter by any of the following:
+      * entity_type;
+      * entity_category;
+      * stationary True/False.
 
-          * entity_type;
-          * entity_category;
-          * stationary True/False.
+    Moreover, sources can also be filtered by generic attributes
+    stored in their description field.
 
-        Moreover, sources can also be filtered by generic attributes
-        stored in their description field.
+    The roi should be specified using one of the following:
+     - circle((center_lon, center_lat), radius_in_meters)
+     - FIXME: rectangle?
+     - FIXME: arbitrary GeoJson?
 
-        The roi should be specified using one of the following:
-         - circle((center_lon, center_lat), radius_in_meters)
-         - FIXME: rectangle?
-         - FIXME: arbitrary GeoJson?
+    **Example request**::
 
-        **Example request**::
+      GET /sources?roi=circle((9.22, 30.0), 1000)
+                  &after=2019-05-02T11:00:00Z
+                  &before=2019-05-02T11:50:25Z HTTP/1.1
 
-          GET /sources?roi=circle((9.22, 30.0), 1000)
-                      &after=2019-05-02T11:00:00Z
-                      &before=2019-05-02T11:50:25Z HTTP/1.1
+      GET /sources?controlledProperties=temperature,humidity
+    (unencoded URL)
 
-          GET /sources?controlledProperties=temperature,humidity
-        (unencoded URL)
+    **Example response**:
 
-        **Example response**:
+    .. sourcecode:: http
 
-        .. sourcecode:: http
+      HTTP/1.1 200 OK
+      Content-Type: application/json
 
-          HTTP/1.1 200 OK
-          Content-Type: application/json
+      [{"tdmq_id": "c034f147-8e54-50bd-97bb-9db1addcdc5a",
+        "id": "source_0",
+        "geometry_type": "Point",
+        "entity_type": "entity_type0},
+       {"tdmq_id": "c034f147-8e54-50bd-97bb-9db1addcdc5b",
+        "id": "source_1",
+        "geometry_type": "Point",
+        "entity_type": "entity_type_1"}]
 
-          [{"tdmq_id": "c034f147-8e54-50bd-97bb-9db1addcdc5a",
-            "id": "source_0",
-            "geometry_type": "Point",
-            "entity_type": "entity_type0},
-           {"tdmq_id": "c034f147-8e54-50bd-97bb-9db1addcdc5b",
-            "id": "source_1",
-            "geometry_type": "Point",
-            "entity_type": "entity_type_1"}]
+    :resheader Content-Type: application/json
 
-        :resheader Content-Type: application/json
+    :query roi: consider only sources with footprint intersecting
+      the given roi e.g., ``circle((9.3, 32), 1000)``
 
-        :query roi: consider only sources with footprint intersecting
-          the given roi e.g., ``circle((9.3, 32), 1000)``
+    :query after: consider only sources reporting  after (included)
+      this time, e.g., ``2019-02-21T11:03:25Z``
 
-        :query after: consider only sources reporting  after (included)
-          this time, e.g., ``2019-02-21T11:03:25Z``
+    :query before: consider only sources reporting strictly before
+      this time, e.g., ``2019-02-22T11:03:25Z``
 
-        :query before: consider only sources reporting strictly before
-          this time, e.g., ``2019-02-22T11:03:25Z``
+    :query {attribute}: select sources whose description has the
+        specified value(s) for the chosen attribute
+        (top-level JSON key, e.g., controlledProperties=temperature)
+    :status 200: no error
+    :returns: list of sources
 
-        :query {attribute}: select sources whose description has the
-            specified value(s) for the chosen attribute
-            (top-level JSON key, e.g., controlledProperties=temperature)
-        :status 200: no error
-        :returns: list of sources
-
-        """
-        if request.method == "GET":
-            with http_request_prom.labels(method='get', endpoint='sources').time():
-                args = {k: v for k, v in request.args.items()}
-                logger.debug("source: args is %s", args)
-                if 'roi' in args:
-                    args['roi'] = convert_roi(args['roi'])
-                if 'controlledProperties' in args:
-                    args['controlledProperties'] = \
-                        args['controlledProperties'].split(',')
-                try:
-                    args['include_private'] = 'false'
-                    res = db.list_sources(args)
-                except tdmq.errors.DBOperationalError:
-                    raise wex.InternalServerError()
-                res = jsonify(res)
-                http_response_prom.labels(method='get', endpoint='sources').observe(
-                    sys.getsizeof(res.data))
-                return res
-        elif request.method == "POST":
-            data = request.json
+    """
+    if request.method == "GET":
+        with current_app.http_request_prom.labels(method='get', endpoint='sources').time():
+            args = {k: v for k, v in request.args.items()}
+            logger.debug("source: args is %s", args)
+            if 'roi' in args:
+                args['roi'] = convert_roi(args['roi'])
+            if 'controlledProperties' in args:
+                args['controlledProperties'] = \
+                    args['controlledProperties'].split(',')
             try:
-                tdmq_ids = db.load_sources(data)
-            except tdmq.errors.DuplicateItemException:
-                raise wex.Conflict()
-            return jsonify(tdmq_ids)
-        else:
-            raise wex.MethodNotAllowed()
-
-    @app.route('/sources/<uuid:tdmq_id>', methods=['GET', 'DELETE'])
-    def source(tdmq_id):
-        """Return description of source with uuid ``tdmq_id``.
-
-        .. :quickref: Get source description
-
-        **Example request**::
-
-          GET /sources/0fd67c67-c9be-45c6-9719-4c4eada4becc HTTP/1.1
-
-        **Example response**:
-
-        .. sourcecode:: http
-
-          HTTP/1.1 200 OK
-          Content-Type: application/json
-
-          {"tdmq_id": "c034f147-8e54-50bd-97bb-9db1addcdc5a",
-           "id": "source_0",
-           "geometry_ype": "Point",
-           "entity_type": "entity_type_0"}
-
-        :resheader Content-Type: application/json
-        :status 200: no error
-        :returns: source description
-        """
-        if request.method == "DELETE":
-            result = db.delete_sources([tdmq_id])
-        else:
-            sources = db.get_sources([tdmq_id], include_private=False)
-            if len(sources) == 1:
-                result = sources[0]
-            elif len(sources) == 0:
-                raise wex.NotFound()
-            else:
-                raise RuntimeError(
-                    f"Got more than one source for tdmq_id {tdmq_id}")
-        return jsonify(result)
-
-    @app.route('/sources/<uuid:tdmq_id>/timeseries')
-    def timeseries(tdmq_id):
-        """Return timeseries for source ``tdmq_id``.
-
-        .. :quickref: Get time series data for source
-
-        For the specified source and time interval, return all records and
-        the corresponding timedeltas array (expressed in seconds from the
-        initial time). Also returns the initial time as "timebase".
-
-        **Example request**::
-
-          GET /sources/0fd67c67-c9be-45c6-9719-4c4eada4becc/
-              timeseries?after=2019-02-21T11:03:25Z
-                        &before=2019-05-02T11:50:25Z HTTP/1.1
-
-        **Example response**:
-
-        .. sourcecode:: http
-
-          HTTP/1.1 200 OK
-          Content-Type: application/json
-
-          {
-            "source_id": "...",
-            "default_footprint": {...},
-            "shape": [...],
-            "bucket": null,
-          <oppure>
-            "bucket": { "interval": 10, "op": "avg" },
-
-            "coords": {
-                "footprint": [...],
-                "time": [...]
-            },
-            "data": {
-              "humidity": [...],
-              "temperature": [...],
-            }
-          }
-
-        :resheader Content-Type: application/json
-
-        :query after: consider only sources reporting after (included)
-                      this time, e.g., '2019-02-21T11:03:25Z'
-
-        :query before: consider only sources reporting strictly before
-                      this time, e.g., '2019-02-22T11:03:25Z'
-
-        :query bucket: time bucket for data aggregation, in seconds,
-                       e.g., 10.33
-
-        :query op: aggregation operation on data contained in bucket,
-                   e.g., `sum`, `count`.
-
-         :query fields: comma-separated controlledProperties from the source,
-                    or nothing to select all of them.
-
-        :status 200: no errors
-        :returns: list of sources
-        """
-
-        with http_request_prom.labels(method='get', endpoint='timeseries').time():
-            rargs = request.args
-            args = dict((k, rargs.get(k, None))
-                        for k in ['after', 'before', 'bucket', 'fields', 'op'])
-            if args['bucket'] is not None:
-                args['bucket'] = timedelta(seconds=float(args['bucket']))
-            if args['fields'] is not None:
-                args['fields'] = args['fields'].split(',')
-
-            # Forces returning data only for private_sources
-            args['include_private'] = False
-
-            try:
-                result = db.get_timeseries(tdmq_id, args)
-            except tdmq.errors.RequestException:
-                logger.error("Bad request getting timeseries")
-                raise wex.BadRequest()
-
-            if len(result["rows"]) == 0:
-                logger.error(
-                    "did not find any timeseries corresponding to required args")
-                raise wex.NotFound()
-
-            res = _restructure_timeseries(result['rows'], result['properties'])
-
-            res["tdmq_id"] = tdmq_id
-            res["default_footprint"] = result['source_info']['default_footprint']
-            res["shape"] = result['source_info']['shape']
-            if args['bucket']:
-                res["bucket"] = {
-                    "interval": args['bucket'].total_seconds(), "op": args.get("op")}
-            else:
-                res['bucket'] = None
+                args['include_private'] = 'false'
+                res = db.list_sources(args)
+            except tdmq.errors.DBOperationalError:
+                raise wex.InternalServerError()
             res = jsonify(res)
-            http_response_prom.labels(method='get', endpoint='timeseries').observe(
+            current_app.http_response_prom.labels(method='get', endpoint='sources').observe(
                 sys.getsizeof(res.data))
             return res
-
-    @app.route('/records', methods=["POST"])
-    def records():
+    elif request.method == "POST":
         data = request.json
-        n = db.load_records(data)
-        return jsonify({"loaded": n})
+        try:
+            tdmq_ids = db.load_sources(data)
+        except tdmq.errors.DuplicateItemException:
+            raise wex.Conflict()
+        return jsonify(tdmq_ids)
+    else:
+        raise wex.MethodNotAllowed()
 
-    @app.route('/service_info')
-    def client_info():
-        response = {
-            'version': '0.1'
+@tdmq_bp.route('/sources/<uuid:tdmq_id>', methods=['GET', 'DELETE'])
+def source(tdmq_id):
+    """Return description of source with uuid ``tdmq_id``.
+
+    .. :quickref: Get source description
+
+    **Example request**::
+
+      GET /sources/0fd67c67-c9be-45c6-9719-4c4eada4becc HTTP/1.1
+
+    **Example response**:
+
+    .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {"tdmq_id": "c034f147-8e54-50bd-97bb-9db1addcdc5a",
+       "id": "source_0",
+       "geometry_ype": "Point",
+       "entity_type": "entity_type_0"}
+
+    :resheader Content-Type: application/json
+    :status 200: no error
+    :returns: source description
+    """
+    if request.method == "DELETE":
+        result = db.delete_sources([tdmq_id])
+    else:
+        srcs = db.get_sources([tdmq_id], include_private=False)
+        if len(srcs) == 1:
+            result = srcs[0]
+        elif len(srcs) == 0:
+            raise wex.NotFound()
+        else:
+            raise RuntimeError(
+                f"Got more than one source for tdmq_id {tdmq_id}")
+    return jsonify(result)
+
+@tdmq_bp.route('/sources/<uuid:tdmq_id>/timeseries')
+def timeseries(tdmq_id):
+    """Return timeseries for source ``tdmq_id``.
+
+    .. :quickref: Get time series data for source
+
+    For the specified source and time interval, return all records and
+    the corresponding timedeltas array (expressed in seconds from the
+    initial time). Also returns the initial time as "timebase".
+
+    **Example request**::
+
+      GET /sources/0fd67c67-c9be-45c6-9719-4c4eada4becc/
+          timeseries?after=2019-02-21T11:03:25Z
+                    &before=2019-05-02T11:50:25Z HTTP/1.1
+
+    **Example response**:
+
+    .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+        "source_id": "...",
+        "default_footprint": {...},
+        "shape": [...],
+        "bucket": null,
+      <oppure>
+        "bucket": { "interval": 10, "op": "avg" },
+
+        "coords": {
+            "footprint": [...],
+            "time": [...]
+        },
+        "data": {
+          "humidity": [...],
+          "temperature": [...],
+        }
+      }
+
+    :resheader Content-Type: application/json
+
+    :query after: consider only sources reporting after (included)
+                  this time, e.g., '2019-02-21T11:03:25Z'
+
+    :query before: consider only sources reporting strictly before
+                  this time, e.g., '2019-02-22T11:03:25Z'
+
+    :query bucket: time bucket for data aggregation, in seconds,
+                   e.g., 10.33
+
+    :query op: aggregation operation on data contained in bucket,
+               e.g., `sum`, `count`.
+
+     :query fields: comma-separated controlledProperties from the source,
+                or nothing to select all of them.
+
+    :status 200: no errors
+    :returns: list of sources
+    """
+
+    with current_app.http_request_prom.labels(method='get', endpoint='timeseries').time():
+        rargs = request.args
+        args = dict((k, rargs.get(k, None))
+                    for k in ['after', 'before', 'bucket', 'fields', 'op'])
+        if args['bucket'] is not None:
+            args['bucket'] = timedelta(seconds=float(args['bucket']))
+        if args['fields'] is not None:
+            args['fields'] = args['fields'].split(',')
+
+        # Forces returning data only for private_sources
+        args['include_private'] = False
+
+        try:
+            result = db.get_timeseries(tdmq_id, args)
+        except tdmq.errors.RequestException:
+            logger.error("Bad request getting timeseries")
+            raise wex.BadRequest()
+
+        if len(result["rows"]) == 0:
+            logger.error(
+                "did not find any timeseries corresponding to required args")
+            raise wex.NotFound()
+
+        res = _restructure_timeseries(result['rows'], result['properties'])
+
+        res["tdmq_id"] = tdmq_id
+        res["default_footprint"] = result['source_info']['default_footprint']
+        res["shape"] = result['source_info']['shape']
+        if args['bucket']:
+            res["bucket"] = {
+                "interval": args['bucket'].total_seconds(), "op": args.get("op")}
+        else:
+            res['bucket'] = None
+        res = jsonify(res)
+        current_app.http_response_prom.labels(method='get', endpoint='timeseries').observe(
+            sys.getsizeof(res.data))
+        return res
+
+@tdmq_bp.route('/records', methods=["POST"])
+def records():
+    data = request.json
+    n = db.load_records(data)
+    return jsonify({"loaded": n})
+
+@tdmq_bp.route('/service_info')
+def client_info():
+    response = {
+        'version': '0.1'
+    }
+
+    if current_app.config.get('TILEDB_VFS_ROOT'):
+        tiledb_conf = {
+            'storage.root': current_app.config['TILEDB_VFS_ROOT']
         }
 
-        if app.config.get('TILEDB_VFS_ROOT'):
-            tiledb_conf = {
-                'storage.root': app.config['TILEDB_VFS_ROOT']
-            }
+        if 'TILEDB_VFS_CONFIG' in current_app.config:
+            tiledb_conf['config'] = current_app.config.get('TILEDB_VFS_CONFIG')
 
-            if 'TILEDB_VFS_CONFIG' in app.config:
-                tiledb_conf['config'] = app.config.get('TILEDB_VFS_CONFIG')
-
-            response['tiledb'] = tiledb_conf
-        return jsonify(response)
+        response['tiledb'] = tiledb_conf
+    return jsonify(response)

--- a/tdmq/app.py
+++ b/tdmq/app.py
@@ -13,7 +13,7 @@ from prometheus_client.utils import INF
 from tdmq.api import tdmq_bp
 from tdmq.db import add_db_cli, close_db
 
-PREFIX = '/api/v0.0'
+DEFAULT_PREFIX = '/api/v0.0'
 
 ERROR_CODES = {
     400: "bad_request",
@@ -53,6 +53,8 @@ def configure_prometheus_registry(app):
 
 class DefaultConfig(object):
     SECRET_KEY = 'dev'
+
+    APP_PREFIX = DEFAULT_PREFIX
 
     DB_HOST = 'timescaledb'
     DB_NAME = 'tdmqtest'
@@ -118,7 +120,7 @@ def create_app(test_config=None):
     add_db_cli(app)
 
     configure_prometheus_registry(app)
-    app.register_blueprint(tdmq_bp, url_prefix=PREFIX)
+    app.register_blueprint(tdmq_bp, url_prefix=app.config['APP_PREFIX'])
 
     @app.errorhandler(wex.HTTPException)
     def handle_errors(e):

--- a/tdmq/wsgi.py
+++ b/tdmq/wsgi.py
@@ -27,7 +27,7 @@ class PrefixMiddleware(object):
 def get_wsgi_app():
     app = create_app()
     prom_app = make_wsgi_app()
-    app.wsgi_app = PrefixMiddleware(app.wsgi_app, prom_app, prefix='/api/v0.0')
+    app.wsgi_app = PrefixMiddleware(app.wsgi_app, prom_app)
     return app
 
 if __name__ == "__main__":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 import pytest
 import tdmq.db
 import tdmq.db_manager as db_manager
-from tdmq.app import create_app
+from tdmq.app import create_app, PREFIX
 
 
 @pytest.fixture(scope="session")
@@ -139,9 +139,6 @@ def tdmq_s3_service_info():
         'tiledb' : {
             'storage.root' : 's3://firstbucket/',
             'config': {
-                #"vfs.s3.endpoint_override": "172.30.10.101:32373",
-                #"vfs.s3.aws_access_key_id": "LM4PV12AXUNDRFRETAO7",
-                #"vfs.s3.aws_secret_access_key": "EBoY38pg4SaU1cK6VkAZ7Li34CAjDKfewZuD4JBm",
                 "vfs.s3.aws_access_key_id": "tdm-user",
                 "vfs.s3.aws_secret_access_key": "tdm-user-s3",
                 "vfs.s3.endpoint_override": "minio:9000",
@@ -361,7 +358,7 @@ TILEDB_VFS_CONFIG = {service_info['tiledb']['config']}
     with tempfile.NamedTemporaryFile(mode='w') as f:
         f.write(cfg)
         f.flush()
-        server = SubprocessLiveServer(f.name, application_path, host, port, '')
+        server = SubprocessLiveServer(f.name, application_path, host, port, PREFIX)
         server.start()
         try:
             yield server

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 import pytest
 import tdmq.db
 import tdmq.db_manager as db_manager
-from tdmq.app import create_app, PREFIX
+from tdmq.app import create_app
 
 
 @pytest.fixture(scope="session")
@@ -94,7 +94,8 @@ def app(db_connection_config):
         'DB_USER': db_connection_config['user'],
         'DB_PASSWORD': db_connection_config['password'],
         'LOG_LEVEL': 'DEBUG',
-        'PROMETHEUS_REGISTRY': True
+        'PROMETHEUS_REGISTRY': True,
+        'APP_PREFIX': ''
     })
 
     app.testing = True
@@ -350,6 +351,7 @@ LOG_LEVEL = "DEBUG"
 PROMETHEUS_REGISTRY = True
 TILEDB_VFS_ROOT = "{service_info['tiledb']['storage.root']}"
 TILEDB_VFS_CONFIG = {service_info['tiledb']['config']}
+APP_PREFIX = ''
     """
 
     application_path = os.path.abspath(os.path.splitext(wsgi.__file__)[0])
@@ -358,7 +360,7 @@ TILEDB_VFS_CONFIG = {service_info['tiledb']['config']}
     with tempfile.NamedTemporaryFile(mode='w') as f:
         f.write(cfg)
         f.flush()
-        server = SubprocessLiveServer(f.name, application_path, host, port, PREFIX)
+        server = SubprocessLiveServer(f.name, application_path, host, port, '')
         server.start()
         try:
             yield server

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from datetime import datetime
 
 import pytest
-from tdmq.app import create_app, PREFIX
+from tdmq.app import create_app
 
 logger = logging.getLogger('test_api')
 
@@ -79,7 +79,7 @@ def test_sources_db_error(flask_client):
     Tests that, if a database error occurs when a client tries to get the sources, it returns a 500 error
     """
     # IMPORTANT: it must be left as first test in the file otherwise it fails since the other tests create the db
-    response = flask_client.get(f'{PREFIX}/sources')
+    response = flask_client.get('/sources')
     assert response.status == '500 INTERNAL SERVER ERROR'
     assert response.get_json() == {"error": "error_retrieving_data"}
 
@@ -88,7 +88,7 @@ def test_sources_db_error(flask_client):
 def test_source_types(flask_client, db_data):
     in_args = {"type": "multisource", "controlledProperties": "temperature"}
     q = "&".join(f"{k}={v}" for k, v in in_args.items())
-    response = flask_client.get(f'{PREFIX}/sources?{q}')
+    response = flask_client.get('/sources?{q}')
     _checkresp(response)
     data = response.get_json()
 
@@ -117,9 +117,9 @@ def test_source_create_duplicate(flask_client, db_data):
         "shape": [],
         "description": {}
     }]
-    response = flask_client.post(f'{PREFIX}/sources', json=source_data)
+    response = flask_client.post('/sources', json=source_data)
     _checkresp(response)
-    response = flask_client.post(f'{PREFIX}/sources', json=source_data)
+    response = flask_client.post('/sources', json=source_data)
     assert response.status == '409 CONFLICT'
     assert response.get_json() == {"error": "duplicated_resource"}
 
@@ -129,14 +129,14 @@ def test_sources_method_not_allowed(flask_client):
     """
     Tests that, if /sources is called using an http method different from POST and GET it returns a 405 METHOD NOT ALLOWED
     """
-    response = flask_client.delete(f'{PREFIX}/sources')
+    response = flask_client.delete('/sources')
     assert response.status == '405 METHOD NOT ALLOWED'
     assert response.get_json() == {"error": "method_not_allowed"}
 
 
 @pytest.mark.sources
 def test_sources_no_args(flask_client, app, db_data, public_source_data):
-    response = flask_client.get(f'{PREFIX}/sources')
+    response = flask_client.get('/sources')
     _checkresp(response)
     data = response.get_json()
     assert isinstance(data, list)
@@ -148,7 +148,7 @@ def test_sources_no_args(flask_client, app, db_data, public_source_data):
 def test_sources_only_geom(flask_client, app, db_data, public_source_data):
     geom = 'circle((9.132, 39.248), 1000)'
     q = f'roi={geom}'
-    response = flask_client.get(f'{PREFIX}/sources?{q}')
+    response = flask_client.get(f'/sources?{q}')
     _checkresp(response)
     data = response.get_json()
     _validate_ids(data, {'tdm/sensor_3', 'tdm/tiledb_sensor_6'})
@@ -158,7 +158,7 @@ def test_sources_only_geom(flask_client, app, db_data, public_source_data):
 def test_sources_active_after_before(flask_client, app, db_data, public_source_data):
     after, before = '2019-05-02T11:30:00Z', '2019-05-02T12:30:00Z'
     q = f'after={after}&before={before}'
-    response = flask_client.get(f'{PREFIX}/sources?{q}')
+    response = flask_client.get(f'/sources?{q}')
     _checkresp(response)
     #  expected = { 'tdm/tiledb_sensor_6' }
     expected = _get_active_sources_in_time_range(
@@ -170,7 +170,7 @@ def test_sources_active_after_before(flask_client, app, db_data, public_source_d
 def test_sources_active_after(flask_client, app, db_data, public_source_data):
     after = '2019-05-02T11:00:22Z'
     q = f'after={after}'
-    response = flask_client.get(f'{PREFIX}/sources?{q}')
+    response = flask_client.get(f'/sources?{q}')
     _checkresp(response)
     #  expected = { 'tdm/sensor_0', 'tdm/sensor_1', 'tdm/tiledb_sensor_6' }
     expected = _get_active_sources_in_time_range(
@@ -182,7 +182,7 @@ def test_sources_active_after(flask_client, app, db_data, public_source_data):
 def test_sources_active_before(flask_client, app, db_data, public_source_data):
     before = '2019-05-02T11:00:00Z'
     q = f'before={before}'
-    response = flask_client.get(f'{PREFIX}/sources?{q}')
+    response = flask_client.get(f'/sources?{q}')
     _checkresp(response)
     #  expected = { 'tdm/sensor_0', 'tdm/sensor_1' }
     expected = _get_active_sources_in_time_range(
@@ -195,7 +195,7 @@ def test_sources_active_after_geom(flask_client, app, db_data, public_source_dat
     geom = 'circle((8.93, 39.0), 10000)'  # point is near the town of Pula
     after = '2019-05-02T11:00:22Z'
     q = f'roi={geom}&after={after}'
-    response = flask_client.get(f'{PREFIX}/sources?{q}')
+    response = flask_client.get(f'/sources?{q}')
     _checkresp(response)
     #  expected = { 'tdm/sensor_0', 'tdm/tiledb_sensor_6' }
     expected = _get_active_sources_in_time_range(
@@ -210,7 +210,7 @@ def test_sources_fail(flask_client):
     geom = 'circle((9.2 33), 1000)'  # note the missing comma
     q = f'roi={geom}'
     with pytest.raises(ValueError) as ve:
-        flask_client.get(f'{PREFIX}/sources?{q}')
+        flask_client.get(f'/sources?{q}')
         assert "roi" in ve.value
         assert geom in ve.value
 
@@ -218,12 +218,12 @@ def test_sources_fail(flask_client):
 @pytest.mark.sources
 def test_source_query_by_tdmq_id(flask_client, app, db_data, public_source_data):
     external_source_id = public_source_data['sources'][0]['id']
-    response_with_id = flask_client.get(f'{PREFIX}/sources?id={external_source_id}')
+    response_with_id = flask_client.get(f'/sources?id={external_source_id}')
     item_with_id = response_with_id.get_json()[0]
     tdmq_id = item_with_id['tdmq_id']
 
     # query again using tdmq_id
-    response_with_tdmq_id = flask_client.get(f"{PREFIX}/sources/{tdmq_id}")
+    response_with_tdmq_id = flask_client.get(f"/sources/{tdmq_id}")
 
     assert item_with_id['external_id'] == response_with_tdmq_id.get_json()[
         'external_id']
@@ -231,12 +231,12 @@ def test_source_query_by_tdmq_id(flask_client, app, db_data, public_source_data)
 
 def test_timeseries(flask_client, app, db_data):
     source_id = 'tdm/sensor_1'
-    response = flask_client.get(f'{PREFIX}/sources?id={source_id}')
+    response = flask_client.get(f'/sources?id={source_id}')
     tdmq_id = response.get_json()[0]['tdmq_id']
 
     bucket, op = 20 * 60, 'sum'
     q = f'bucket={bucket}&op={op}'
-    response = flask_client.get(f'{PREFIX}/sources/{tdmq_id}/timeseries?{q}')
+    response = flask_client.get(f'/sources/{tdmq_id}/timeseries?{q}')
     _checkresp(response)
     d = response.get_json()
 
@@ -256,13 +256,13 @@ def test_timeseries(flask_client, app, db_data):
 
 def test_timeseries_for_private_sources(flask_client, app, db_data):
     source_id = 'tdm/sensor_7'
-    response = flask_client.get(f'{PREFIX}/sources?id={source_id}')
+    response = flask_client.get(f'/sources?id={source_id}')
     assert response.status == '200 OK'
     _checkresp(response, [])
 
 
 def test_service_info(flask_client):
-    resp = flask_client.get(f'{PREFIX}/service_info')
+    resp = flask_client.get(f'/service_info')
     _checkresp(resp)
     info = resp.json
     assert info.get('version') is not None
@@ -276,11 +276,12 @@ def test_app_config_tiledb():
     hdfs_user = 'pippo'
     config = {
         'TILEDB_VFS_ROOT': hdfs_root,
-        'TILEDB_VFS_CONFIG': { 'vfs.hdfs.username': hdfs_user }
+        'TILEDB_VFS_CONFIG': { 'vfs.hdfs.username': hdfs_user },
+        'APP_PREFIX': ''
     }
 
     with _create_new_app_test_client(config) as client:
-        resp = client.get(f'{PREFIX}/service_info')
+        resp = client.get(f'/service_info')
         _checkresp(resp)
         info = resp.json
         assert 'tiledb' in info
@@ -290,22 +291,22 @@ def test_app_config_tiledb():
 
 def test_app_config_no_tiledb():
     config = {
-        'TILEDB_VFS_ROOT': None
+        'TILEDB_VFS_ROOT': None,
+        'APP_PREFIX': ''
     }
 
     with _create_new_app_test_client(config) as client:
-        resp = client.get(f'{PREFIX}/service_info')
+        resp = client.get(f'/service_info')
         _checkresp(resp)
         info = resp.json
         assert 'tiledb' not in info
 
 
 def test_app_config_from_file(monkeypatch):
-    hdfs_root = 'hdfs://someserver:8020/'
-    cfg = f"""
-TILEDB_VFS_ROOT = '{hdfs_root}'
-TILEDB_VFS_CONFIG = {{ 'vfs.hdfs.username': 'hdfs_user' }}
-    """
+    vfs_root = 's3://mybucket/'
+    cfg = f"TILEDB_VFS_ROOT = '{vfs_root}'\n" \
+           "TILEDB_VFS_CONFIG = { 'vfs.s3.property': 'bla' }\n" \
+           "APP_PREFIX = ''"
 
     with tempfile.NamedTemporaryFile(mode='w') as f:
         f.write(cfg)
@@ -313,9 +314,9 @@ TILEDB_VFS_CONFIG = {{ 'vfs.hdfs.username': 'hdfs_user' }}
 
         monkeypatch.setenv('TDMQ_FLASK_CONFIG', f.name)
         with _create_new_app_test_client() as client:
-            resp = client.get(f'{PREFIX}/service_info')
+            resp = client.get(f'/service_info')
             _checkresp(resp)
             info = resp.json
             assert 'tiledb' in info
-            assert info['tiledb']['storage.root'] == hdfs_root
-            assert info['tiledb']['config']['vfs.hdfs.username'] == 'hdfs_user'
+            assert info['tiledb']['storage.root'] == vfs_root
+            assert info['tiledb']['config']['vfs.s3.property'] == 'bla'


### PR DESCRIPTION
This PR builds on the PR #53 to refactor the definition of API routes as a Flask blueprint and parameterize the application prefix (e.g., `/api/v0.0`).  It also updates the version of pytest used by the project.