### PR TITLE
Remove trailing slashes from tdmq url/prefix

### DIFF
--- a/tdmq/app.py
+++ b/tdmq/app.py
@@ -110,6 +110,9 @@ def create_app(test_config=None):
     elif 'TDMQ_FLASK_CONFIG' in os.environ:
         app.config.from_envvar('TDMQ_FLASK_CONFIG')
 
+    # Strip any trailing slashes from the prefix
+    app.config['APP_PREFIX'] = app.config['APP_PREFIX'].rstrip('/')
+
     configure_logging(app)
 
     try:

--- a/tdmq/client/client.py
+++ b/tdmq/client/client.py
@@ -34,6 +34,8 @@ class Client:
         self.base_url = (tdmq_base_url or
                          os.getenv('TDMQ_BASE_URL') or
                          self.DEFAULT_TDMQ_BASE_URL)
+        # Strip any trailing slashes from the prefix
+        self.base_url = self.base_url.rstrip('/')
 
         _logger.debug("New tdmq client object for %s", self.base_url)
 

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -2,6 +2,14 @@
 from tdmq.client import Client
 
 
+def test_strip_trailing_slash_from_url():
+    some_url = 'http://web:8080/some_url'
+    c = Client(some_url)
+    assert c.base_url == some_url
+    c = Client(some_url + '/')
+    assert c.base_url == some_url
+
+
 def test_connect(live_app):
     c = Client(live_app.url())
     assert not c.connected


### PR DESCRIPTION
Remove trailing slashes from tdmq service URL provided to Client and from app prefix in tdmq configuration file.