### PR TITLE
Fix accidental modification of config object

### DIFF
--- a/tdmq/api.py
+++ b/tdmq/api.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import sys
 from datetime import timedelta
@@ -197,6 +198,9 @@ def service_info_get():
             tiledb_conf['config'] = current_app.config.get('TILEDB_VFS_CONFIG')
 
         if 'TILEDB_VFS_CREDENTIALS' in current_app.config and _request_authorized():
+            # We're recycling the configuration object in the response.  Copy
+            # it before merging in the credentials to avoid modifying it.
+            tiledb_conf['config'] = copy.deepcopy(tiledb_conf['config'])
             tiledb_conf['config'].update(current_app.config.get('TILEDB_VFS_CREDENTIALS'))
 
         response['tiledb'] = tiledb_conf

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -437,6 +437,16 @@ def test_get_service_info_authenticated(flask_client):
     assert 'tiledb' in info
     assert 'vfs.s3.aws_access_key_id' in info['tiledb']['config']
     assert 'vfs.s3.aws_secret_access_key' in info['tiledb']['config']
+    # Request again without authentication
+    resp = flask_client.get(f'/service_info')
+    _checkresp(resp)
+    info = resp.json
+    assert 'tiledb' in info
+    assert 'vfs.s3.aws_access_key_id' not in info['tiledb']['config']
+    assert 'vfs.s3.aws_secret_access_key' not in info['tiledb']['config']
+
+
+
 
 @pytest.mark.config
 def test_app_config_tiledb():


### PR DESCRIPTION
`/service_info` was accidentally reusing part of the configuration object to form its response and modifying it in place, altering the configuration returned to subsequent calls.  This PR introduces a test to detect this problem and fixes the issue.