### PR TITLE
Keep tiledb arrays open for multiple accesses

### DIFF
--- a/tdmq/client/sources.py
+++ b/tdmq/client/sources.py
@@ -1,9 +1,15 @@
+
+import abc
+import logging
+from collections.abc import Iterable
+from collections.abc import Mapping
+from contextlib import contextmanager
+
 from tdmq.client.timeseries import ScalarTimeSeries
 from tdmq.client.timeseries import NonScalarTimeSeries
 from tdmq.errors import UnsupportedFunctionality
-import abc
-from collections.abc import Iterable
-from collections.abc import Mapping
+
+_logger = logging.getLogger(__name__)
 
 
 class Source(abc.ABC):
@@ -54,15 +60,67 @@ class ScalarSource(Source):
 
 
 class NonScalarSource(Source):
+    def __init__(self, client, tdmq_id, desc):
+        super().__init__(client, tdmq_id, desc)
+        self._tiledb_array = None
+
+
+    def __del__(self):
+        _logger.debug("NonScalarSource destructor")
+        self.close_array()
+
+
+    def close_array(self):
+        if self._tiledb_array:
+            _logger.debug("NonScalarSource: closing array")
+            try:
+                self._tiledb_array.close()
+            finally:
+                self._tiledb_array = None
+
+
+    def open_array(self, mode='r'):
+        if mode not in ('r', 'w'):
+            raise ValueError(f"Invalid mode {mode}")
+
+        if not self._tiledb_array:
+            _logger.debug("NonScalarSource: opening array %s with mode %s", self.tdmq_id, mode)
+            self._tiledb_array = self.client.open_array(self.tdmq_id, mode)
+        elif mode not in self._tiledb_array.mode:
+            _logger.debug("NonScalarSource: array %s opened in incompatible mode. Reopening with mode %s", self.tdmq_id, mode)
+            self.client.close_array(self._tiledb_array)
+            self._tiledb_array = None
+            self._tiledb_array = self.client.open_array(self.tdmq_id, mode)
+
+
+    @contextmanager
+    def array_context(self, mode='r'):
+        self.open_array(mode)
+        try:
+            yield
+        finally:
+            self.close_array()
+
+
+    def get_array(self):
+        if not self._tiledb_array:
+            raise RuntimeError("Array not open!")
+        return self._tiledb_array
+
+
     def timeseries(self, after=None, before=None, bucket=None, op=None):
+        self.open_array(mode='r')
         return NonScalarTimeSeries(self, after, before, bucket, op)
 
+
     def ingest(self, t, data, slot=None):
+        self.open_array(mode='w')
+
         if slot is None:
             raise UnsupportedFunctionality(f'No auto-slot support yet.')
         for p in self.controlled_properties:
             if p not in data:
                 raise ValueError(f'data is missing field {p}')
-        self.client.save_tiledb_frame(self.tdmq_id, slot, data)
+        self.client.save_tiledb_frame(self.get_array(), slot, data)
         self.add_record({'time': t.strftime(self.client.TDMQ_DT_FMT),
                          'data': {'tiledb_index': slot}})

--- a/tdmq/client/timeseries.py
+++ b/tdmq/client/timeseries.py
@@ -86,17 +86,20 @@ class NonScalarTimeSeries(TimeSeries):
     def __init__(self, source, after, before, bucket, op):
         if bucket:
             raise NotImplementedError("Bucketing is not yet implemented in the client for non-scalar timeseries")
-        super(NonScalarTimeSeries, self).__init__(source, after, before, bucket, op)
+        super().__init__(source, after, before, bucket, op)
+
 
     def fetch(self):
         raw_data = self._pre_fetch()
         self.tiledb_indices = raw_data['tiledb_index']
 
+
     def fetch_data_block(self, args):
         if self.bucket is None:
-            return self.source.client.fetch_non_scalar_slice(self.source.tdmq_id, self.tiledb_indices, args)
+            return self.source.client.fetch_non_scalar_slice(self.source.get_array(), self.tiledb_indices, args)
         else:
             raise ValueError('bucket not supported')
+
 
     def get_item(self, args):
         assert len(args) > 0

--- a/tests/client/test_non_scalar_source.py
+++ b/tests/client/test_non_scalar_source.py
@@ -178,3 +178,16 @@ def test_nonscalar_source_add_records(clean_storage, source_data, live_app):
         c.deregister_source(s)
         tdmq_ids.append(tdmq_id)
     check_deallocation(c, tdmq_ids)
+
+
+def test_nonscalar_source_array_context(clean_storage, source_data, live_app):
+    N = 3
+    c = Client(live_app.url(), auth_token=live_app.auth_token)
+    srcs = register_nonscalar_sources(c, source_data)
+    logging.debug("Registered %s sources", len(srcs))
+    for s in srcs:
+        logging.debug("source: id %s, shape: %s; type: %s", s.id, s.shape, type(s))
+        assert len(s.shape) > 0
+        with s.array_context('w'):
+            create_and_ingest_records(s, N)
+        c.deregister_source(s)


### PR DESCRIPTION
Seeing that opening tiledb arrays can be relatively time-consuming, this (backwards-compatible) change to the client opens the array on the first use and keeps it open until it is explicitly closed (through `NonScalarSource.close_array`) or the source is garbage-collected.

**This change does mean that array insertions won't be flushed to disk immediately.**

For finer control on array lifetime, the PR also introduces a context manager which can be used as in:

    source = client.get_source("id")
    with source.array_context('w'):
        source.ingest(...)
        source.ingest(...)
        source.ingest(...)
