### PR TITLE
Reuse DB connection for multiple requests

### DIFF
--- a/tdmq/app.py
+++ b/tdmq/app.py
@@ -1,5 +1,6 @@
 
 
+import atexit
 import logging
 import os
 import secrets
@@ -13,6 +14,9 @@ from prometheus_client.utils import INF
 
 from tdmq.api import tdmq_bp
 from tdmq.db import add_db_cli, close_db
+
+## This is the best way I've found to close the DB connect when the application exits.
+atexit.register(close_db)
 
 DEFAULT_PREFIX = '/api/v0.0'
 
@@ -144,9 +148,5 @@ def create_app(test_config=None):
     @app.errorhandler(wex.HTTPException)
     def handle_errors(e):
         return jsonify({"error": ERROR_CODES.get(e.code)}), e.code
-
-    @app.teardown_appcontext
-    def teardown_db(arg):
-        close_db()
 
     return app

--- a/tdmq/db_manager.py
+++ b/tdmq/db_manager.py
@@ -1,10 +1,11 @@
 
 import logging
 import os
-import psycopg2 as psy
-import psycopg2.sql as sql
 
 from contextlib import contextmanager
+
+import psycopg2 as psy
+import psycopg2.sql as sql
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 
 import tdmq.utils

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,8 +123,10 @@ def app(db_connection_config, auth_token):
     })
 
     app.testing = True
-    with app.app_context():
-        yield app
+    try:
+        with app.app_context():
+            yield app
+    finally:
         tdmq.db.close_db()
 
 


### PR DESCRIPTION
This PR causes the DB connection to be cached in a module variable and be reused for all requests.  Previously the DB connection was reused only for each single request.