### PR TITLE
Expose `anonymized` parameter in Client.get_source

### DIFF
--- a/tdmq/api-spec.yaml
+++ b/tdmq/api-spec.yaml
@@ -195,7 +195,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SourceBrief'
+                $ref: '#/components/schemas/SourceGet'
 
     post:
       description: >
@@ -568,7 +568,7 @@ components:
         - "var_pop"
         - "var_samp"
 
-    SourceBrief:
+    SourceGet:
       description: "Short source representation"
       type: object
       properties:
@@ -587,27 +587,20 @@ components:
         entity_type:
           description: "One of the entity types returned by /entity_types"
           type: string
+        stationary:
+          description: "Whether the source moves or is stationary"
+          type: boolean
+        description:
+          description: "Free-form object describing the source"
+          type: object
       required:
         - tdmq_id
         - external_id
         - default_footprint
         - entity_category
         - entity_type
-
-    SourceGet:
-      allOf:
-        - $ref: '#/components/schemas/SourceBrief'
-        - type: object
-          required:
-            - stationary
-            - description
-          properties:
-            stationary:
-              description: "Whether the source moves or is stationary"
-              type: boolean
-            description:
-              description: "Free-form object describing the source"
-              type: object
+        - stationary
+        - description
 
     SourcePost:
       type: object

--- a/tdmq/client/client.py
+++ b/tdmq/client/client.py
@@ -156,7 +156,7 @@ class Client:
     @requires_connection
     def get_source(self, tdmq_id, anonymized=True):
         res = self._do_get(f'sources/{tdmq_id}', params={'anonymized': anonymized})
-        assert res['tdmq_id'] == tdmq_id
+        assert res['tdmq_id'] == str(tdmq_id)
         return self.__source_factory(res)
 
     @requires_connection

--- a/tdmq/client/client.py
+++ b/tdmq/client/client.py
@@ -149,8 +149,8 @@ class Client:
         return [self.get_source(r['tdmq_id']) for r in res]
 
     @requires_connection
-    def get_source(self, tdmq_id):
-        res = self._do_get(f'sources/{tdmq_id}')
+    def get_source(self, tdmq_id, anonymized=True):
+        res = self._do_get(f'sources/{tdmq_id}', params={'anonymized': anonymized})
         assert res['tdmq_id'] == tdmq_id
 
         if res['description'].get('shape'):

--- a/tdmq/client/sources.py
+++ b/tdmq/client/sources.py
@@ -25,6 +25,23 @@ class Source(abc.ABC):
         self.shape = tuple(self.description.get('shape', ()))
         self.controlled_properties = self.description['controlledProperties']
 
+
+    @property
+    def public(self):
+        return self.description.get('public', False)
+
+    def __repr__(self):
+        return repr({
+            'self.tdmq_id ': self.tdmq_id,
+            'self.id ': self.id,
+            'self.entity_category ': self.entity_category,
+            'self.entity_type ': self.entity_type,
+            'self.default_footprint ': self.default_footprint,
+            'self.is_stationary ': self.is_stationary,
+            'self.shape ': self.shape,
+            'self.controlled_properties ': self.controlled_properties,
+            'self.description ': self.description })
+
     def get_timeseries(self, args):
         return self.client.get_timeseries(self.tdmq_id, args)
 

--- a/tests/client/test_source.py
+++ b/tests/client/test_source.py
@@ -59,9 +59,9 @@ def test_register_deregister_simple_source_as_admin(clean_storage, public_source
 def test_register_simple_source_as_user(clean_storage, public_source_data, live_app):
     c = Client(live_app.url())
 
-    with pytest.raises(HTTPError) as ve:
-        srcs = register_scalar_sources(c, public_source_data)
-        ve.code = 401
+    with pytest.raises(HTTPError) as exc_info:
+        _ = register_scalar_sources(c, public_source_data)
+    assert exc_info.value.response.status_code == 401
 
 
 def test_deregister_simple_source_as_user(clean_storage, public_source_data, live_app):
@@ -71,9 +71,9 @@ def test_deregister_simple_source_as_user(clean_storage, public_source_data, liv
 
     # then tries to deregister it with user client
     c = Client(live_app.url())
-    with pytest.raises(HTTPError) as ve:
+    with pytest.raises(HTTPError) as exc_info:
         c.deregister_source(srcs[0])
-        assert ve.code == 401
+    assert exc_info.value.response.status_code == 401
 
 
 def test_select_source_by_id(clean_storage, public_source_data, live_app):

--- a/tests/client/test_source.py
+++ b/tests/client/test_source.py
@@ -114,9 +114,7 @@ def test_find_source_by_roi_as_user(clean_storage, db_data, live_app):
     assert external_ids == { 'tdm/sensor_3', 'tdm/tiledb_sensor_6' }
 
 
-def test_find_anonymized_and_not_anonymized(clean_storage, db_data, source_data, live_app, caplog):
-    import logging
-    caplog.set_level(logging.DEBUG)
+def test_find_anonymized_and_not_anonymized(clean_storage, db_data, source_data, live_app):
     c = Client(live_app.url())
     sources = c.find_sources(args={'only_public': 'false'})
     assert len(sources) == len(source_data['sources'])


### PR DESCRIPTION
This PR exposes the `anonymized` API parameter in Client.get_source.  It also updates the API spec to reflect the fact that the two `GET /source/` API calls have been returning identical structures for a while, and it updates the client to take advantage of this by not doing a GET for every source in `Client.find_sources`.