### PR TITLE
Make the `id` attribute public

### DIFF
--- a/tdmq/api-spec.yaml
+++ b/tdmq/api-spec.yaml
@@ -176,6 +176,16 @@ paths:
           description: >
              Comma-separated list of property names required of source.
           type: string
+        - name: "id"
+          in: query
+          type: string
+          description: >
+            External id of source.
+        - name: "external_id"
+          in: query
+          type: string
+          description: >
+            Alias for `id`.  The `external_id` parameter takes precedence over `id`.
         - name: "attribute"
           in: query
           schema:
@@ -587,6 +597,11 @@ components:
         entity_type:
           description: "One of the entity types returned by /entity_types"
           type: string
+        public:
+          description: >
+            Whether this is a public source -- i.e., whether its attributes and
+            the data it produces are anonymous and public.
+          type: boolean
         stationary:
           description: "Whether the source moves or is stationary"
           type: boolean
@@ -599,6 +614,7 @@ components:
         - default_footprint
         - entity_category
         - entity_type
+        - public
         - stationary
         - description
 

--- a/tdmq/client/sources.py
+++ b/tdmq/client/sources.py
@@ -25,6 +25,13 @@ class Source(abc.ABC):
         self.shape = tuple(self.description.get('shape', ()))
         self.controlled_properties = self.description['controlledProperties']
 
+    @property
+    def external_id(self):
+        return self.id
+
+    @external_id.setter
+    def external_id(self, v):
+        self.id = v
 
     @property
     def public(self):

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -92,7 +92,7 @@ def test_get_anonymized_source(clean_storage, db_data, source_data, live_app):
     tdmq_id = _compute_tdmq_id(a_private_source['id'])
 
     src = c.get_source(tdmq_id)
-    assert src.id is None
+    assert src.description.get('alias') is None
 
     with pytest.raises(HTTPError) as exc_info:
         c.get_source(tdmq_id, anonymized=False)

--- a/tests/client/test_source.py
+++ b/tests/client/test_source.py
@@ -47,6 +47,8 @@ def test_register_deregister_simple_source_as_admin(clean_storage, public_source
     for s in srcs:
         assert s.tdmq_id in sources
         assert s.id == sources[s.tdmq_id].id
+        assert s.external_id == sources[s.tdmq_id].id
+        assert s.external_id == s.id
         assert s.tdmq_id == sources[s.tdmq_id].tdmq_id
         tdmq_id = s.tdmq_id
         c.deregister_source(s)
@@ -81,6 +83,8 @@ def test_select_source_by_id(clean_storage, public_source_data, live_app):
     srcs = register_scalar_sources(c, public_source_data)
     for s in srcs:
         s2 = c.find_sources({'id': s.id})
+        assert len(s2) == 1
+        s2 = c.find_sources({'external_id': s.id})
         assert len(s2) == 1
     for s in srcs:
         c.deregister_source(s)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,6 +7,7 @@ from datetime import datetime
 
 import pytest
 from tdmq.app import create_app
+from tdmq.model import Source
 
 logger = logging.getLogger('test_api')
 
@@ -368,19 +369,8 @@ def test_private_source_query_by_tdmq_id_unauthenticated(flask_client, db_data, 
     struct = response.get_json()
     valued_keys = [ k for k in struct.keys() if struct[k] is not None ]
     assert private_source_tdmq_id == struct['tdmq_id']
-    assert set(valued_keys) <= set(('description',
-                                    'default_footprint',
-                                    'entity_category',
-                                    'entity_type',
-                                    'public',
-                                    'stationary',
-                                    'tdmq_id'))
-    assert set(struct['description'].keys()) <= set(('controlledProperties',
-                                                     'description',
-                                                     'entity_category',
-                                                     'entity_type',
-                                                     'shape',
-                                                     'stationary'))
+    assert set(valued_keys) <= (Source.SafeKeys | { 'description', 'default_footprint' })
+    assert set(struct['description'].keys()) <= Source.SafeDescriptionKeys
     point = struct['default_footprint']
     assert point['type'] == 'Point'
     assert point['coordinates'] != [ 9.111872, 39.214212 ]
@@ -409,19 +399,8 @@ def test_private_source_query_by_tdmq_id_authenticated(flask_client, db_data, so
     struct = response.get_json()
     valued_keys = [ k for k in struct.keys() if struct[k] is not None ]
     assert private_source_tdmq_id == struct['tdmq_id']
-    assert set(valued_keys) <= set(('description',
-                                    'default_footprint',
-                                    'entity_category',
-                                    'entity_type',
-                                    'public',
-                                    'stationary',
-                                    'tdmq_id'))
-    assert set(struct['description'].keys()) <= set(('controlledProperties',
-                                                     'description',
-                                                     'entity_category',
-                                                     'entity_type',
-                                                     'shape',
-                                                     'stationary'))
+    assert set(valued_keys) <= (Source.SafeKeys | { 'description', 'default_footprint' })
+    assert set(struct['description'].keys()) <= Source.SafeDescriptionKeys
     point = struct['default_footprint']
     assert point['type'] == 'Point'
     assert point['coordinates'] != [ 9.111872, 39.214212 ]


### PR DESCRIPTION
The id attribute is required to be able to recognize specific devices.