### PR TITLE
Refactor client attributes and add new edge/station/sensor ids

### DIFF
--- a/tdmq/client/sources.py
+++ b/tdmq/client/sources.py
@@ -16,31 +16,61 @@ class Source(abc.ABC):
     def __init__(self, client, tdmq_id, desc):
         self.client = client
         self.tdmq_id = tdmq_id
-        self.id = desc['external_id']
-        self.entity_category = desc['entity_category']
-        self.entity_type = desc['entity_type']
-        self.is_stationary = desc['stationary']
-        self.default_footprint = desc['default_footprint']
-        self.description = desc['description']
-        self.shape = tuple(self.description.get('shape', ()))
-        self.controlled_properties = self.description['controlledProperties']
+        self._full_body = desc
 
+    def _get_info(self):
+        return self._full_body['description']['description']
+
+    @property
+    def id(self):
+        return self._full_body.get('external_id')
+
+    @property
+    def default_footprint(self):
+        return self._full_body['default_footprint']
+
+    @property
+    def is_stationary(self):
+        return self._full_body['stationary']
+
+    @property
+    def entity_category(self):
+        return self._full_body['entity_category']
+
+    @property
+    def entity_type(self):
+        return self._full_body['entity_type']
+
+    @property
+    def registration_time(self):
+        return self._full_body['registration_time']
 
     @property
     def public(self):
-        return self.description.get('public', False)
+        return self._full_body.get('public', False)
+
+    @property
+    def alias(self):
+        return self._full_body['description'].get('alias')
+
+    @property
+    def shape(self):
+        return tuple(self._full_body['description'].get('shape', ()))
+
+    @property
+    def controlled_properties(self):
+        return self._full_body['description']['controlledProperties']
 
     def __repr__(self):
         return repr({
-            'self.tdmq_id ': self.tdmq_id,
-            'self.id ': self.id,
-            'self.entity_category ': self.entity_category,
-            'self.entity_type ': self.entity_type,
-            'self.default_footprint ': self.default_footprint,
-            'self.is_stationary ': self.is_stationary,
-            'self.shape ': self.shape,
-            'self.controlled_properties ': self.controlled_properties,
-            'self.description ': self.description })
+            'tdmq_id ': self.tdmq_id,
+            'id ': self.id,
+            'entity_category ': self.entity_category,
+            'entity_type ': self.entity_type,
+            'default_footprint ': self.default_footprint,
+            'is_stationary ': self.is_stationary,
+            'shape ': self.shape,
+            'controlled_properties ': self.controlled_properties })
 
     def get_timeseries(self, args):
         return self.client.get_timeseries(self.tdmq_id, args)
@@ -66,6 +96,39 @@ class Source(abc.ABC):
 
 
 class ScalarSource(Source):
+
+    @property
+    def sensor_id(self):
+        return self._get_info().get('sensor_id')
+
+    @property
+    def station_id(self):
+        return self._get_info().get('station_id')
+
+    @property
+    def station_model(self):
+        return self._get_info().get('station_model')
+
+    @property
+    def edge_id(self):
+        return self._get_info().get('edge_id')
+
+    def __repr__(self):
+        return repr({
+            'tdmq_id ':               self.tdmq_id,
+            'id ':                    self.id,
+            'entity_category ':       self.entity_category,
+            'entity_type ':           self.entity_type,
+            'default_footprint ':     self.default_footprint,
+            'is_stationary ':         self.is_stationary,
+            'shape ':                 self.shape,
+            'controlled_properties ': self.controlled_properties,
+            'edge_id':                self.edge_id,
+            'station_id':             self.station_id,
+            'station_model':          self.station_model,
+            'sensor_id':              self.sensor_id,
+            })
+
     def timeseries(self, after=None, before=None, bucket=None, op=None):
         return ScalarTimeSeries(self, after, before, bucket, op)
 

--- a/tdmq/db.py
+++ b/tdmq/db.py
@@ -111,6 +111,7 @@ def list_sources(args=None, limit=None, offset=None):
             entity_category,
             entity_type,
             description,
+            registration_time,
             public
         FROM source""")
 
@@ -204,6 +205,7 @@ def get_sources(list_of_tdmq_ids):
             entity_category,
             entity_type,
             description,
+            registration_time,
             public
         FROM source
         WHERE tdmq_id = ANY(%s)""")

--- a/tdmq/model.py
+++ b/tdmq/model.py
@@ -60,6 +60,10 @@ class Source:
         'shape',
         'stationary',
         'type',
+        'edge_id',
+        'station_model',
+        'station_id',
+        'sensor_id',
         }
 
     @staticmethod
@@ -95,6 +99,10 @@ class Source:
         'public',
         'roi',
         'stationary',
+        'edge_id',
+        'station_id',
+        'station_model',
+        'sensor_id',
         }
 
     @classmethod

--- a/tests/client/test_source.py
+++ b/tests/client/test_source.py
@@ -98,6 +98,28 @@ def test_select_sources_by_entity_type(clean_storage, public_source_data, live_a
         # FIXME: add assertions
 
 
+def test_access_attributes_scalar_source(clean_storage, db_data, public_source_data, live_app):
+    c = Client(live_app.url())
+    src_id = 'tdm/sensor_3'
+    sources = c.find_sources(args={'id': src_id})
+    assert len(sources) == 1
+    s = sources[0]
+    original = next(s for s in public_source_data['sources'] if s['id'] == src_id)
+    assert s.id                         == original['id']
+    assert s.is_stationary              == original.get('stationary', True)
+    assert s.entity_category            == original['entity_category']
+    assert s.entity_type                == original['entity_type']
+    assert s.public                     == original['public']
+    assert s.alias                      == original['alias']
+    assert len(s.shape)                 == 0
+    assert set(s.controlled_properties) == set(original['controlledProperties'])
+    assert s.edge_id                    == original['description']['edge_id']
+    assert s.station_id                 == original['description']['station_id']
+    assert s.station_model              == original['description']['station_model']
+    assert s.sensor_id                  == original['description']['sensor_id']
+    assert s.registration_time          is not None
+
+
 def test_find_source_by_roi(clean_storage, db_data, live_app):
     c = Client(live_app.url(), auth_token=live_app.auth_token)
     geom = 'circle((9.132, 39.248), 1000)'

--- a/tests/data/sources.json
+++ b/tests/data/sources.json
@@ -65,14 +65,21 @@
                 ]
             },
             "controlledProperties": [
-                "power"
+                "apparentPower",
+                "consumedEnergy",
+                "current",
+                "frequency",
+                "meterPulses",
+                "powerFactor",
+                "realPower",
+                "voltage"
             ],
             "shape": [],
             "description": {
-                "type": "power sensor",
-                "brandName": "ProSensor",
-                "modelName": "C3PO",
-                "manufacturerName": "CRS4"
+                "edge_id": "edge-12d45e",
+                "station_model": "IoTaWatt",
+                "station_id": "IOTAWATT",
+                "sensor_id": "L"
             },
             "public": true
         },


### PR DESCRIPTION
Refactor the client `Source` class to explicitly define the attributes that should be defined and accessible.  This also shields all client code from the structure returned by the API, making it easier for us to change that in the future should be decide to review some old decisions.

Finally, the PR adds the new Source metadata attributes providing source, station, and sensor ids.