### PR TITLE
Refactor search params

### DIFF
--- a/tdmq/api-spec.yaml
+++ b/tdmq/api-spec.yaml
@@ -176,6 +176,16 @@ paths:
           description: >
              Comma-separated list of property names required of source.
           type: string
+        - name: "id"
+          in: query
+          type: string
+          description: >
+            External id of source.
+        - name: "external_id"
+          in: query
+          type: string
+          description: >
+            Alias for `id`.  The `external_id` parameter takes precedence over `id`.
         - name: "attribute"
           in: query
           schema:
@@ -587,6 +597,11 @@ components:
         entity_type:
           description: "One of the entity types returned by /entity_types"
           type: string
+        public:
+          description: >
+            Whether this is a public source -- i.e., whether its attributes and
+            the data it produces are anonymous and public.
+          type: boolean
         stationary:
           description: "Whether the source moves or is stationary"
           type: boolean
@@ -599,6 +614,7 @@ components:
         - default_footprint
         - entity_category
         - entity_type
+        - public
         - stationary
         - description
 

--- a/tdmq/client/sources.py
+++ b/tdmq/client/sources.py
@@ -26,6 +26,10 @@ class Source(abc.ABC):
         return self._full_body.get('external_id')
 
     @property
+    def external_id(self):
+        return self.id
+
+    @property
     def default_footprint(self):
         return self._full_body['default_footprint']
 

--- a/tdmq/model.py
+++ b/tdmq/model.py
@@ -32,6 +32,7 @@ class Source:
     ROI_CENTER_DIGITS = 3
     ROI_RADIUS_INCREMENT = 500
 
+    # Property required by Source structure, as specified in the API spec.
     RequiredKeys = frozenset({
         'default_footprint',
         'description',
@@ -43,24 +44,21 @@ class Source:
         'tdmq_id',
         })
 
+    # Keys in Source structure that do not require anonymization
     SafeKeys = frozenset({
         'entity_category',
         'entity_type',
-        'external_id',
         'public',
         'stationary',
         'tdmq_id'})
 
+    # Keys in Source.description structure that do not require anonymization
     SafeDescriptionKeys = frozenset({
         'brandName',
         'controlledProperties',
-        'description',
-        'entity_category',
-        'entity_type',
         'manufacturerName',
         'modelName',
         'shape',
-        'stationary',
         'type',
         'edge_id',
         'station_model',
@@ -92,6 +90,7 @@ class Source:
     def delete_one(tdmq_id: str) -> None:
         db.delete_sources([tdmq_id])
 
+    # AcceptedSearchKeys: set of search parameters accepted for source search.
     AcceptedSearchKeys = frozenset({
         'after',
         'before',
@@ -102,10 +101,6 @@ class Source:
         'public',
         'roi',
         'stationary',
-        'edge_id',
-        'station_id',
-        'station_model',
-        'sensor_id',
         })
 
     @classmethod
@@ -165,7 +160,8 @@ class Source:
                limit: int=None, offset: int=None) -> list:
         """
         search_args: any from AcceptedSearchKeys
-        match_attr:  general attribute matching
+        match_attr:  general attribute matching in the
+        Source.description.description structure.
         """
         if limit or offset:
             raise NotImplementedError("Limit and offset are not implemented")

--- a/tdmq/model.py
+++ b/tdmq/model.py
@@ -32,24 +32,26 @@ class Source:
     ROI_CENTER_DIGITS = 3
     ROI_RADIUS_INCREMENT = 500
 
-    RequiredKeys = {
-        'tdmq_id',
-        'external_id',
+    RequiredKeys = frozenset({
         'default_footprint',
-        'entity_category',
-        'entity_type',
-        'stationary',
         'description',
-        }
-
-    SafeKeys = {
         'entity_category',
         'entity_type',
+        'external_id',
         'public',
         'stationary',
-        'tdmq_id'}
+        'tdmq_id',
+        })
 
-    SafeDescriptionKeys = {
+    SafeKeys = frozenset({
+        'entity_category',
+        'entity_type',
+        'external_id',
+        'public',
+        'stationary',
+        'tdmq_id'})
+
+    SafeDescriptionKeys = frozenset({
         'brandName',
         'controlledProperties',
         'description',
@@ -64,7 +66,7 @@ class Source:
         'station_model',
         'station_id',
         'sensor_id',
-        }
+        })
 
     @staticmethod
     def store_new(data: Iterable[dict]) -> List[str]:
@@ -90,11 +92,12 @@ class Source:
     def delete_one(tdmq_id: str) -> None:
         db.delete_sources([tdmq_id])
 
-    AcceptedSearchKeys = {
+    AcceptedSearchKeys = frozenset({
         'after',
         'before',
         'entity_category',
         'entity_type',
+        'external_id',
         'id',
         'public',
         'roi',
@@ -103,7 +106,7 @@ class Source:
         'station_id',
         'station_model',
         'sensor_id',
-        }
+        })
 
     @classmethod
     def _anonymize_source(cls, src_dict: dict) -> dict:
@@ -160,29 +163,39 @@ class Source:
     @classmethod
     def search(cls, search_args: Dict[str, Any], match_attr: Dict[str, Any]=None, anonymize_private: bool=True,
                limit: int=None, offset: int=None) -> list:
+        """
+        search_args: any from AcceptedSearchKeys
+        match_attr:  general attribute matching
+        """
         if limit or offset:
             raise NotImplementedError("Limit and offset are not implemented")
 
-        public = search_args.get('public', None)
+        query_args = search_args.copy() # copy so we can modify the dictionary
+
+        e_id = query_args.pop('external_id', None)
+        if e_id:
+            query_args['id'] = e_id
+
+        public = query_args.get('public', None)
         # unless the request is exclusively for public sources, tweak the ROI to limit precision
-        if not public and 'roi' in search_args:
-            cls._quantize_roi(search_args['roi'])
+        if not public and 'roi' in query_args:
+            cls._quantize_roi(query_args['roi'])
 
         if match_attr:
-            search_args.update(match_attr)
+            query_args.update(match_attr)
 
-        if not (cls.SafeKeys >= search_args.keys() and \
+        if not (cls.SafeKeys >= query_args.keys() and \
                 cls.SafeDescriptionKeys >= match_attr.keys()):
             # can't do query on private sources because it uses unsafe attributes
-            search_args['public'] = True
+            query_args['public'] = True
 
-        raw = db.list_sources(search_args)
+        raw = db.list_sources(query_args)
         resultset = [ r for r in raw if r['public'] ]
         private_it = (r for r in raw if not r['public'])
         if anonymize_private:
             private_it = cls._anonymizing_iter(private_it)
-        if 'roi' in search_args:
-            private_it = cls._roi_intersection_filter(search_args['roi'], private_it)
+        if 'roi' in query_args:
+            private_it = cls._roi_intersection_filter(query_args['roi'], private_it)
         resultset.extend(private_it)
 
         return resultset

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -92,7 +92,7 @@ def test_get_anonymized_source(clean_storage, db_data, source_data, live_app):
     tdmq_id = _compute_tdmq_id(a_private_source['id'])
 
     src = c.get_source(tdmq_id)
-    assert src.id is None
+    assert src.alias is None
 
     with pytest.raises(HTTPError) as exc_info:
         c.get_source(tdmq_id, anonymized=False)

--- a/tests/client/test_source.py
+++ b/tests/client/test_source.py
@@ -47,6 +47,8 @@ def test_register_deregister_simple_source_as_admin(clean_storage, public_source
     for s in srcs:
         assert s.tdmq_id in sources
         assert s.id == sources[s.tdmq_id].id
+        assert s.external_id == sources[s.tdmq_id].id
+        assert s.external_id == s.id
         assert s.tdmq_id == sources[s.tdmq_id].tdmq_id
         tdmq_id = s.tdmq_id
         c.deregister_source(s)
@@ -81,6 +83,8 @@ def test_select_source_by_id(clean_storage, public_source_data, live_app):
     srcs = register_scalar_sources(c, public_source_data)
     for s in srcs:
         s2 = c.find_sources({'id': s.id})
+        assert len(s2) == 1
+        s2 = c.find_sources({'external_id': s.id})
         assert len(s2) == 1
     for s in srcs:
         c.deregister_source(s)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,6 +7,7 @@ from datetime import datetime
 
 import pytest
 from tdmq.app import create_app
+from tdmq.model import Source
 
 logger = logging.getLogger('test_api')
 
@@ -368,19 +369,8 @@ def test_private_source_query_by_tdmq_id_unauthenticated(flask_client, db_data, 
     struct = response.get_json()
     valued_keys = [ k for k in struct.keys() if struct[k] is not None ]
     assert private_source_tdmq_id == struct['tdmq_id']
-    assert set(valued_keys) <= set(('description',
-                                    'default_footprint',
-                                    'entity_category',
-                                    'entity_type',
-                                    'public',
-                                    'stationary',
-                                    'tdmq_id'))
-    assert set(struct['description'].keys()) <= set(('controlledProperties',
-                                                     'description',
-                                                     'entity_category',
-                                                     'entity_type',
-                                                     'shape',
-                                                     'stationary'))
+    assert set(valued_keys) <= (Source.SafeKeys | { 'description', 'default_footprint' })
+    assert set(struct['description'].keys()) <= Source.SafeDescriptionKeys
     point = struct['default_footprint']
     assert point['type'] == 'Point'
     assert point['coordinates'] != [ 9.111872, 39.214212 ]
@@ -409,19 +399,8 @@ def test_private_source_query_by_tdmq_id_authenticated(flask_client, db_data, so
     struct = response.get_json()
     valued_keys = [ k for k in struct.keys() if struct[k] is not None ]
     assert private_source_tdmq_id == struct['tdmq_id']
-    assert set(valued_keys) <= set(('description',
-                                    'default_footprint',
-                                    'entity_category',
-                                    'entity_type',
-                                    'public',
-                                    'stationary',
-                                    'tdmq_id'))
-    assert set(struct['description'].keys()) <= set(('controlledProperties',
-                                                     'description',
-                                                     'entity_category',
-                                                     'entity_type',
-                                                     'shape',
-                                                     'stationary'))
+    assert set(valued_keys) <= (Source.SafeKeys | { 'description', 'default_footprint' })
+    assert set(struct['description'].keys()) <= Source.SafeDescriptionKeys
     point = struct['default_footprint']
     assert point['type'] == 'Point'
     assert point['coordinates'] != [ 9.111872, 39.214212 ]


### PR DESCRIPTION
Small refactoring of source search and api-spec, plus the addition of tests on search for sources matching new scalar sensor attributes (i.e., `edge_id`, `station_id`, etc.)