### PR TITLE
Feature/prometheus exporter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,12 +64,14 @@ run: base-images docker/docker-compose.yml
 	docker-compose -f ./docker/docker-compose.yml up
 
 startdev: base-images docker/docker-compose-dev.yml
+	chmod a+r ./docker/prometheus.yml
 	docker-compose -f ./docker/docker-compose-dev.yml up -d
 
 stopdev:
 	docker-compose -f ./docker/docker-compose-dev.yml down
 
 start: base-images docker/docker-compose.yml
+	chmod a+r ./docker/prometheus.yml
 	docker-compose -f ./docker/docker-compose.yml up -d
 	# Try to wait for timescaleDB and HDFS
 	docker-compose -f ./docker/docker-compose.yml exec timescaledb bash -c 'for i in {{1..8}}; do sleep 5; pg_isready && break; done || { echo ">> Timed out waiting for timescaleDB" >&2; exit 2; }'

--- a/docker/Dockerfile.tdmq-client-conda
+++ b/docker/Dockerfile.tdmq-client-conda
@@ -42,10 +42,15 @@ COPY --chown=root ./tdmq-dist/tdmq/requirements-server.txt "${TDMQ_DIST}/tdmq/"
 # psycopg2 instead of psycopg2-binary.
 # We fix the name on-the-fly with sed with a quick process substitution (which
 # requires bash).
-# We also remove the logging_tree package, which is not available on conda.
+# We also remove the logging_tree package, which is not available on conda,
+# and rename prometheus-flask-exporter to prometheus_flask_exporter, to map the
+# package name on pypi to conda.
 RUN /bin/bash -c \
     'mamba install -c conda-forge --yes --file <(\
-        sed -e 's/psycopg2-binary/psycopg2/' -e '/logging_tree/d' "${TDMQ_DIST}/tdmq/requirements-server.txt")' \
+        sed -e 's/psycopg2-binary/psycopg2/' \
+            -e '/logging_tree/d' \
+            -e 's/prometheus-flask-exporter/prometheus_flask_exporter/' \
+            "${TDMQ_DIST}/tdmq/requirements-server.txt")' \
  && mamba clean --all -y
 
 # FIXME: This section is copied and pasted from the image build process for

--- a/docker/docker-compose.yml-tmpl
+++ b/docker/docker-compose.yml-tmpl
@@ -3,7 +3,7 @@ version: "3"
 services:
 
   prometheus:
-    image: prom/prometheus:v2.18.1
+    image: prom/prometheus:v2.24.1
     ports:
       - "9090:9090"
     volumes:
@@ -39,6 +39,7 @@ services:
     environment:
       - "CREATE_DB=false"
       - "DEV=false"
+    #DEV   - "DEBUG_METRICS=true"
     #DEV volumes:
     #DEV - "LOCAL_PATH/tdmq:/tdmq-dist/tdmq"
     healthcheck:

--- a/docker/docker-compose.yml-tmpl
+++ b/docker/docker-compose.yml-tmpl
@@ -47,7 +47,6 @@ services:
       interval: "30s"
       timeout: "5s"
       retries: "3"
-      start_period: "15s"
 
   namenode:
     image: crs4/namenode:3.2.0

--- a/docker/docker-compose.yml-tmpl
+++ b/docker/docker-compose.yml-tmpl
@@ -41,6 +41,12 @@ services:
       - "DEV=false"
     #DEV volumes:
     #DEV - "LOCAL_PATH/tdmq:/tdmq-dist/tdmq"
+    healthcheck:
+      test: [ "CMD", "/usr/bin/curl", "http://web:8000/api/v0.0/entity_types" ]
+      interval: "30s"
+      timeout: "5s"
+      retries: "3"
+      start_period: "15s"
 
   namenode:
     image: crs4/namenode:3.2.0

--- a/docker/prometheus.yml
+++ b/docker/prometheus.yml
@@ -1,6 +1,6 @@
 global:
   evaluation_interval: 1m
-  scrape_interval: 1m
+  scrape_interval: 10s
   scrape_timeout: 10s
 rule_files:
 - /etc/config/rules
@@ -13,7 +13,7 @@ scrape_configs:
 - job_name: tdmq
   static_configs:
   - targets:
-    - web:8000  
+    - web:8000
 # alerting:
 #   alertmanagers:
 #   - kubernetes_sd_configs:

--- a/tdmq/requirements-server.txt
+++ b/tdmq/requirements-server.txt
@@ -13,3 +13,4 @@ shapely
 pyproj
 pyshp
 logging_tree
+prometheus-flask-exporter>=0.18,<0.19

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -722,3 +722,9 @@ def test_convert_roi():
                    'radius': 4000.0 }
     rv = convert_roi("circle( (9.14, 39.25), 4000)")
     assert rv['center']['coordinates'] == [9.14, 39.25]
+
+
+def test_metrics_get(flask_client):
+    response = flask_client.get('/metrics')
+    assert response.status_code == 200
+    assert response.content_length > 0


### PR DESCRIPTION
Port tdmq metrics from the basic Prometheus client to the [prometheus-flask-export package](https://pypi.org/project/prometheus-flask-exporter/).

The previous implementation was also missing the configuration of a `/metrics` endpoint, which is added by this PR.