### PR TITLE
Expose tiledb extent size and attribute properties

### DIFF
--- a/tdmq/app.py
+++ b/tdmq/app.py
@@ -58,6 +58,7 @@ def configure_logging(app):
     # 2. `root`, with handler `basic`: used for everything else.
     log_config = {
         'version': 1,
+        'disable_existing_loggers': False, # if not specified defaults to True
         'formatters': {
             'default': {
                 'format': '[%(asctime)s] %(levelname)s in %(module)s: %(message)s',
@@ -97,7 +98,11 @@ def configure_logging(app):
     else:
         error = True
 
-    dictConfig(log_config)
+    if not app.config['TESTING']:
+        dictConfig(log_config)
+    else:
+        app.logger.info("Not configuring loggers since we're running in testing mode")
+
     if error:
         app.logger.error("LOG_LEVEL value %s is invalid. Defaulting to %s", level_str, log_config['root']['level'])
 

--- a/tdmq/requirements-client.txt
+++ b/tdmq/requirements-client.txt
@@ -1,4 +1,4 @@
 
-tiledb-py==0.6.6
+tiledb-py==0.8.4
 requests>=2,<3
 setuptools

--- a/tdmq/utils.py
+++ b/tdmq/utils.py
@@ -1,6 +1,7 @@
 
 import os
 import re
+import time
 
 from contextlib import contextmanager
 
@@ -40,3 +41,13 @@ def find_exec(name):
         if os.access(full_path, os.X_OK | os.R_OK):
             return full_path
     return None
+
+
+@contextmanager
+def timeit(log_fn, template_msg="Duration: %0.5f"):
+    start = time.time()
+    try:
+        yield
+    finally:
+        duration = time.time() - start
+        log_fn(template_msg, duration)

--- a/tests/client/test_non_scalar_source.py
+++ b/tests/client/test_non_scalar_source.py
@@ -213,3 +213,17 @@ def test_nonscalar_source_custom_attr_data_type(clean_storage, source_data, live
         ary = s.get_array()
         assert ary.attr('VMI').dtype == np.int32
         assert ary.attr('SRI').dtype == np.float32
+
+
+def test_consolidate(clean_storage, source_data, live_app, caplog):
+    c = Client(live_app.url(), auth_token=live_app.auth_token)
+    src = next(s for s in source_data['sources'] if s['id'] == "tdm/tiledb_sensor_6")
+    s = c.register_source(src, nslots=600)
+    with caplog.at_level(logging.DEBUG):
+        s.consolidate()
+    valid_modes = ('fragments', 'fragment_meta')
+    for m in valid_modes:
+        assert f"Executing {m} consolidation on array" in caplog.text
+        assert f"Executing {m} vacuum on array" in caplog.text
+    # We don't run array metadata vacuuming.  Fails in tests
+    assert f"Executing array_meta consolidation on array" in caplog.text

--- a/tests/client/test_non_scalar_source.py
+++ b/tests/client/test_non_scalar_source.py
@@ -89,13 +89,11 @@ def test_basic_tiledb_s3_operativity(clean_storage, service_info_with_creds):
 
     a = np.arange(5)
     logging.debug("trying to write array to s3: %s", array_name)
-    schema = tiledb.schema_like(a, ctx=ctx)
-    tiledb.DenseArray.create(array_name, schema)
-    with tiledb.DenseArray(array_name, 'w', ctx=ctx) as T:
+    with tiledb.empty_like(array_name, a, ctx=ctx) as T:
         T[:] = a
 
     logging.debug("reading back s3-backed array %s ", array_name)
-    with tiledb.DenseArray(array_name, ctx=ctx) as t:
+    with tiledb.open(array_name, ctx=ctx) as t:
         assert (t[0:5] == a).all()
 
 


### PR DESCRIPTION
This PR adds parameters to the Client, in a backwards compatible way, to expose the configuration of tiledb array extent sizes and some aspects of the array schema: specifically, attribute data type and filter list.  The interface is set up to easily support additional attribute properties.

The PR also changes the calculation of the default extent sizes as to generate defaults that empirically seem to work better.