### PR TITLE
handle timezones in timestamps

### DIFF
--- a/tdmq/client/sources.py
+++ b/tdmq/client/sources.py
@@ -87,6 +87,9 @@ class Source(abc.ABC):
         pass
 
     def get_latest_activity(self):
+        """
+        Get Timeseries starting at latest registered record's timestamp.
+        """
         s = self.client.get_latest_source_activity(self.tdmq_id)
         return self.timeseries(after=s['time'], before=None)
 
@@ -95,14 +98,21 @@ class Source(abc.ABC):
     ###
     @abc.abstractmethod
     def ingest_one(self, t, data, slot=None, footprint=None):
-        pass
+        """
+        :param t: datetime object.  Assumed to be in UTC time.
+        """
 
     def ingest(self, t, data, slot=None):
+        """
+        :param t: datetime object.  Assumed to be in UTC time.
+        """
         self.ingest_one(t, data, slot)
 
     @abc.abstractmethod
     def ingest_many(self, times, data, initial_slot=None, footprint_iter=None):
-        pass
+        """
+        :param times: Sequence of datetime objects.  Assumed to be in UTC time.
+        """
 
 
 class ScalarSource(Source):
@@ -144,7 +154,8 @@ class ScalarSource(Source):
 
     def _format_record(self, t, d, foot=None):
         record = {
-            'time': t.strftime(self.client.TDMQ_DT_FMT),
+            # pylint: disable=protected-access
+            'time': self.client._format_timestamp(t),
             'data': d,
             'tdmq_id': self.tdmq_id }
         if foot:

--- a/tdmq/client/timeseries.py
+++ b/tdmq/client/timeseries.py
@@ -1,7 +1,6 @@
 import abc
 import warnings
 import numpy as np
-from datetime import datetime
 
 
 class TimeSeries(abc.ABC):
@@ -27,7 +26,8 @@ class TimeSeries(abc.ABC):
                 'bucket': self.bucket, 'op': self.op}
 
         res = self.source.get_timeseries(args)
-        self.time = np.array([datetime.fromtimestamp(v) for v in res['coords']['time']])
+        # pylint: disable=protected-access
+        self.time = np.array([self.source.client._parse_timestamp(v) for v in res['coords']['time']])
 
         return res['data']
 
@@ -44,7 +44,7 @@ class TimeSeries(abc.ABC):
             1. np.ndarray of timestamps
             2. OrderedDict mapping property names to  np.ndarrays containing the actual data.
         """
-        pass
+
 
     def __len__(self):
         return len(self.time)

--- a/tests/client/test_non_scalar_source.py
+++ b/tests/client/test_non_scalar_source.py
@@ -2,7 +2,7 @@
 
 import logging
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import numpy as np
 import pytest
@@ -21,7 +21,7 @@ def create_data_frame(shape, properties, fill_value):
 
 
 def create_and_ingest_records(source, nrecs):
-    now = datetime.now()
+    now = datetime.now(tz=timezone.utc)
     t = now
     dt = timedelta(seconds=10)
     for slot in range(nrecs):
@@ -240,7 +240,7 @@ def test_ingest_one(clean_storage, source_data, live_app):
         'VMI': np.full(s.shape, 1),
         'SRI': np.full(s.shape, 2.0)
         }
-    now = datetime.now()
+    now = datetime.now(tz=timezone.utc)
     with s.array_context('w'):
         s.ingest_one(now, data, slot=1)
     with s.array_context('r'):
@@ -261,7 +261,7 @@ def test_ingest_one_auto_slot(clean_storage, source_data, live_app):
         'VMI': np.full(s.shape, 1),
         'SRI': np.full(s.shape, 2.0)
         }
-    now = datetime.now()
+    now = datetime.now(tz=timezone.utc)
     with s.array_context('w'):
         s.ingest_one(now, data, slot=None)
 
@@ -288,7 +288,7 @@ def test_ingest_many_to_be_stacked(clean_storage, source_data, live_app):
         'VMI': [ np.full(s.shape, i) for i in range(n_elements) ],
         'SRI': [ np.full(s.shape, i * 2.0) for i in range(n_elements) ]
         }
-    now = datetime.now()
+    now = datetime.now(tz=timezone.utc)
     interval = timedelta(minutes=5)
     times = [ now + interval * i for i in range(n_elements) ]
     with s.array_context('w'):
@@ -318,7 +318,7 @@ def test_ingest_many_to_be_stacked_auto_slot(clean_storage, source_data, live_ap
         'VMI': [ np.full(s.shape, i) for i in range(n_elements) ],
         'SRI': [ np.full(s.shape, i * 2.0) for i in range(n_elements) ]
         }
-    now = datetime.now()
+    now = datetime.now(tz=timezone.utc)
     interval = timedelta(minutes=5)
     times = [ now + interval * i for i in range(n_elements) ]
     with s.array_context('w'):

--- a/tests/client/test_source.py
+++ b/tests/client/test_source.py
@@ -126,8 +126,6 @@ def test_access_attributes_scalar_source_private_unauthenticated(clean_storage, 
     src_id = 'tdm/sensor_7'
     tdmq_id = _compute_tdmq_id(src_id)
     s = c.get_source(tdmq_id)
-    print("----------------------------")
-    print("Source._full_body:\n", s._full_body)
     original = next(t for t in source_data['sources'] if t['id'] == src_id)
     assert s.id                         is None
     assert s.is_stationary              == original.get('stationary', True)
@@ -171,10 +169,4 @@ def test_repr(clean_storage, db_data, live_app):
     c = Client(live_app.url())
     sources = c.find_sources(args={'only_public': 'false'})
     for s in sources:
-        try:
-            assert repr(s)
-        except KeyError as e:
-            print("==============================")
-            print(e)
-            print("Source._full_body:\n", s._full_body)
-            raise
+        assert repr(s)

--- a/tests/client/test_timeseries.py
+++ b/tests/client/test_timeseries.py
@@ -1,5 +1,5 @@
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import numpy as np
 import pytest
@@ -31,8 +31,7 @@ def test_check_timeseries_range(clean_storage, clean_db, live_app):
     c = Client(live_app.url(), auth_token=live_app.auth_token)
     s = c.register_source(source_desc)
     N = 10
-    now = datetime.now()
-    time_base = datetime(now.year, now.month, now.day, now.hour)
+    time_base = datetime.now(tz=timezone.utc).replace(minute=0, second=0, microsecond=0)
     times = [time_base + timedelta(i) for i in range(N)]
     temps = [20 + i for i in range(N)]
     hums = [i / N for i in range(N)]
@@ -51,8 +50,7 @@ def test_check_timeseries_ingest_many(clean_storage, clean_db, live_app):
     c = Client(live_app.url(), auth_token=live_app.auth_token)
     s = c.register_source(source_desc)
     N = 10
-    now = datetime.now()
-    time_base = datetime(now.year, now.month, now.day, now.hour)
+    time_base = datetime.now(tz=timezone.utc).replace(minute=0, second=0, microsecond=0)
     times = [time_base + timedelta(i) for i in range(N)]
     temps = [20 + i for i in range(N)]
     hums = [i / N for i in range(N)]
@@ -72,8 +70,7 @@ def test_check_timeseries_bucket(clean_storage, clean_db, live_app):
     s = c.register_source(source_desc)
     bucket = 10
     N = 10 * bucket
-    now = datetime.now()
-    time_base = datetime(now.year, now.month, now.day, now.hour)
+    time_base = datetime.now(tz=timezone.utc).replace(minute=0, second=0, microsecond=0)
     times = [time_base + timedelta(seconds=i) for i in range(N)]
     temps = [20 + i for i in range(N)]
     hums = [i / N for i in range(N)]
@@ -110,7 +107,7 @@ def test_source_get_latest_activity(clean_storage, public_db_data, live_app):
     ts = s.get_latest_activity()
     assert len(ts) == 1
     timestamp = ts[-1][0]
-    assert timestamp == datetime.fromisoformat("2019-05-02T11:20:00")
+    assert timestamp == datetime.fromisoformat("2019-05-02T11:20:00+00:00")
 
 
 def test_create_timeseries_range_as_user(clean_storage, clean_db, live_app):
@@ -124,8 +121,7 @@ def test_create_timeseries_range_as_user(clean_storage, clean_db, live_app):
     s = c.get_source(tdmq_id)
 
     N = 1
-    now = datetime.now()
-    time_base = datetime(now.year, now.month, now.day, now.hour)
+    time_base = datetime.now(tz=timezone.utc).replace(minute=0, second=0, microsecond=0)
     times = [time_base + timedelta(i) for i in range(N)]
     temps = [20 + i for i in range(N)]
     hums = [i / N for i in range(N)]
@@ -141,8 +137,7 @@ def test_check_timeseries_range_as_user(clean_storage, clean_db, live_app):
     s = c.register_source(source_desc)
     bucket = 10
     N = 10 * bucket
-    now = datetime.now()
-    time_base = datetime(now.year, now.month, now.day, now.hour)
+    time_base = datetime.now(tz=timezone.utc).replace(minute=0, second=0, microsecond=0)
     times = [time_base + timedelta(seconds=i) for i in range(N)]
     temps = [20 + i for i in range(N)]
     hums = [i / N for i in range(N)]


### PR DESCRIPTION
The polystore stores all timestamps in UTC.  This PR fixes the client to:
* consider timezone information provided in ingested timestamps;
* include timezone in all returned timestamps.

The current client implementation ignores the user-provided timezone, if any.  This means that a `datetime` created in local Rome time will erroneously be saved as its face value instead of being shifted to UTC.