### PR TITLE
Import `Source` and `TimeSeries` into `tdmq.client`

### DIFF
--- a/tdmq/client/__init__.py
+++ b/tdmq/client/__init__.py
@@ -1,1 +1,3 @@
 from .client import Client, log_level, set_log_level
+from .sources import Source
+from .timeseries import TimeSeries

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -97,3 +97,7 @@ def test_get_anonymized_source(clean_storage, db_data, source_data, live_app):
     with pytest.raises(HTTPError) as exc_info:
         c.get_source(tdmq_id, anonymized=False)
     assert exc_info.value.response.status_code == 401 # unauthorized
+
+def test_imports():
+    from tdmq.client import Source
+    from tdmq.client import TimeSeries


### PR DESCRIPTION
This PR simply imports the `Source` and `TimeSeries` into the `tdmq.client` module, making it easier to import them into client code.