### PR TITLE
Expose the ability in client to query timeseries only for specific fields

### DIFF
--- a/tdmq/client/sources.py
+++ b/tdmq/client/sources.py
@@ -83,7 +83,7 @@ class Source(abc.ABC):
         return self.client.get_timeseries(self.tdmq_id, args)
 
     @abc.abstractmethod
-    def timeseries(self, after, before, bucket=None, op=None):
+    def timeseries(self, after, before, bucket=None, op=None, properties=None):
         pass
 
     def get_latest_activity(self):
@@ -149,8 +149,8 @@ class ScalarSource(Source):
             'sensor_id':              self.sensor_id,
             })
 
-    def timeseries(self, after=None, before=None, bucket=None, op=None):
-        return ScalarTimeSeries(self, after, before, bucket, op)
+    def timeseries(self, after=None, before=None, bucket=None, op=None, properties=None):
+        return ScalarTimeSeries(self, after, before, bucket, op, properties)
 
     def _format_record(self, t, d, foot=None):
         record = {
@@ -229,7 +229,7 @@ class NonScalarSource(Source):
         return self._tiledb_array
 
 
-    def timeseries(self, after=None, before=None, bucket=None, op=None):
+    def timeseries(self, after=None, before=None, bucket=None, op=None, properties=None):
         self.open_array(mode='r')
         return NonScalarTimeSeries(self, after, before, bucket, op)
 

--- a/tests/client/test_timeseries.py
+++ b/tests/client/test_timeseries.py
@@ -206,3 +206,13 @@ def test_timeseries_step_index(clean_storage, db_data, source_data, live_app):
     assert abs(times[0] - parse_timestamp(records[0]['time'])) < timedelta(seconds=1)
     assert abs(times[1] - parse_timestamp(records[2]['time'])) < timedelta(seconds=1)
     assert abs(times[2] - parse_timestamp(records[4]['time'])) < timedelta(seconds=1)
+
+
+def test_timeseries_properties_subset(clean_storage, db_data, live_app):
+    c = Client(live_app.url())
+    s = c.find_sources(args={'id': 'tdm/sensor_1'})[0]
+    ts = s.timeseries()
+    assert len(ts.series.keys()) == len(s.controlled_properties)
+    ts = s.timeseries(properties=['temperature'])
+    assert len(ts.series.keys()) == 1
+    assert 'temperature' in ts.series.keys()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -523,6 +523,7 @@ def test_get_empty_timeseries(flask_client, app, db_data):
     _checkresp(response)
     d = response.get_json()
     assert 'temperature' in d['data']
+    assert len(d['data'].keys()) == 1
     assert d['data']['temperature'] == []
 
 


### PR DESCRIPTION
Adds `properties` argument to `Source.timeseries` to allow fetching only a subset of the full set of a source's controlled properties.