### PR TITLE
Feature/stream timeseries

### DIFF
--- a/tdmq/api-spec.yaml
+++ b/tdmq/api-spec.yaml
@@ -335,6 +335,9 @@ paths:
         *  fields: comma-separated controlledProperties from the source,
                 or nothing to select all of them.
 
+        * sparse: boolean requesting sparse or dense format.
+                  Default: TDMq decides based on query.
+
         ## Example response
 
         ```
@@ -342,21 +345,15 @@ paths:
           Content-Type: application/json
 
           {
-            "source_id": "...",
+            "tdmq_id": "...",
             "default_footprint": {...},
             "shape": [...],
+            "fields": [...],
             "bucket": null,
           <oppure>
             "bucket": { "interval": 10, "op": "avg" },
 
-            "coords": {
-                "footprint": [...],
-                "time": [...]
-            },
-            "data": {
-              "humidity": [...],
-              "temperature": [...],
-            }
+            "items": [...]
           }
         ```
 

--- a/tdmq/api.py
+++ b/tdmq/api.py
@@ -183,7 +183,6 @@ def sources_delete(tdmq_id):
 
 @tdmq_bp.route('/sources/<uuid:tdmq_id>/timeseries')
 def timeseries_get_stream(tdmq_id):
-    logger.debug("Calling timeseries_get_stream")
     rargs = request.args
 
     anonymize_private = str_to_bool(rargs.get('anonymized', 'true'))
@@ -203,7 +202,13 @@ def timeseries_get_stream(tdmq_id):
         # requested by the query.
         sparse_format = bool(args['fields'])
 
-    result = Timeseries.get_one_by_batch(tdmq_id, anonymize_private, args)
+    batch_size = int(rargs.get('batch_size', -1))
+    if batch_size <= 0:
+        batch_size = None
+    else:
+        logger.debug("GET requested batch_size of %s", batch_size)
+
+    result = Timeseries.get_one_by_batch(tdmq_id, anonymize_private, batch_size, args)
 
     def format_sparse_row(row: List) -> str:
         assert len(row) == len(result.fields)

--- a/tdmq/api.py
+++ b/tdmq/api.py
@@ -198,9 +198,9 @@ def timeseries_get_stream(tdmq_id):
     if rargs.get('sparse'):
         sparse_format = str_to_bool(rargs['sparse'])
     else:
-        # By default, use a sparse format if only a subset of the possible fields is 
+        # By default, use a dense format if only a subset of the fields is
         # requested by the query.
-        sparse_format = bool(args['fields'])
+        sparse_format = not bool(args['fields'])
 
     batch_size = int(rargs.get('batch_size', -1))
     if batch_size <= 0:

--- a/tdmq/api.py
+++ b/tdmq/api.py
@@ -212,7 +212,8 @@ def timeseries_get_stream(tdmq_id):
 
     def format_sparse_row(row: List) -> str:
         assert len(row) == len(result.fields)
-        return json.dumps(dict(zip(result.fields, row)))
+        d = {field_name: value for field_name, value in zip(result.fields, row) if value is not None}
+        return json.dumps(d)
 
     def format_dense_row(row: List) -> str:
         return json.dumps(row)

--- a/tdmq/app.py
+++ b/tdmq/app.py
@@ -13,10 +13,10 @@ from flask import request
 from prometheus_client import Histogram
 from prometheus_client.utils import INF
 from prometheus_flask_exporter import PrometheusMetrics
-try:
-    from logging_tree.format import build_description
-except ImportError:
-    pass
+# try:
+#     from logging_tree.format import build_description
+# except ImportError:
+#     pass
 
 from tdmq.api import tdmq_bp
 from tdmq.db import add_db_cli, close_db

--- a/tdmq/client/client.py
+++ b/tdmq/client/client.py
@@ -271,6 +271,7 @@ class Client:
     @requires_connection
     def get_timeseries(self, code, args):
         args = dict((k, v) for k, v in args.items() if v is not None)
+        # for testing!  args['batch_size'] = 1
         _logger.debug('get_timeseries(%s, %s)', code, args)
         return self._do_get(f'sources/{code}/timeseries', params=args)
 

--- a/tdmq/client/client.py
+++ b/tdmq/client/client.py
@@ -289,6 +289,18 @@ class Client:
             return req.json()
 
     @requires_connection
+    def export_timeseries(self, code, args, data_format: str = 'csv', chunk_size=16384):
+        if data_format != 'csv':
+            raise NotImplementedError("only CSV export is supported")
+        _logger.debug('export_timeseries(%s, %s, data_format=%s, chunk_size=%s)',
+                      code, args, data_format, chunk_size)
+        args = dict((k, v) for k, v in args.items() if v is not None)
+        args['format'] = data_format
+        with self._do_get_stream_ctx(f'sources/{code}/timeseries', params=args) as req:
+            for chunk in req.iter_content(chunk_size=chunk_size):
+                yield chunk
+
+    @requires_connection
     def get_latest_source_activity(self, tdmq_id):
         _logger.debug("get_latest_source_activity(%s)", tdmq_id)
         r = self._do_get(f'sources/{tdmq_id}/activity/latest')

--- a/tdmq/client/client.py
+++ b/tdmq/client/client.py
@@ -269,8 +269,10 @@ class Client:
         return self.__source_factory(res)
 
     @requires_connection
-    def get_timeseries(self, code, args):
+    def get_timeseries(self, code, args, sparse: bool = None):
         args = dict((k, v) for k, v in args.items() if v is not None)
+        if sparse is not None:
+            args['sparse'] = sparse
         # for testing!  args['batch_size'] = 1
         _logger.debug('get_timeseries(%s, %s)', code, args)
         return self._do_get(f'sources/{code}/timeseries', params=args)

--- a/tdmq/client/sources.py
+++ b/tdmq/client/sources.py
@@ -104,8 +104,8 @@ class Source(abc.ABC):
             'comments ': self.comments,
             })
 
-    def get_timeseries(self, args):
-        return self.client.get_timeseries(self.tdmq_id, args)
+    def get_timeseries(self, args, sparse: bool = None):
+        return self.client.get_timeseries(self.tdmq_id, args, sparse)
 
     @abc.abstractmethod
     def timeseries(self, after, before, bucket=None, op=None, properties=None):

--- a/tdmq/client/timeseries.py
+++ b/tdmq/client/timeseries.py
@@ -7,14 +7,43 @@ import numpy as np
 class TimeSeries(abc.ABC):
 
     def __init__(self, source, after, before, bucket, op, properties=None):
-        self.source = source
-        self.after = after
-        self.before = before
-        self.bucket = bucket
-        self.op = op
-        self.time = None
-        self.properties = properties
-        self._fetch()
+        self._source = source
+        self._after = after
+        self._before = before
+        self._bucket = bucket
+        self._op = op
+        self._time = None
+        self._properties = properties
+
+    @property
+    def source(self):
+        return self._source
+
+    @property
+    def after(self):
+        return self._after
+
+    @property
+    def before(self):
+        return self._before
+
+    @property
+    def bucket(self):
+        return self._bucket
+
+    @property
+    def op(self):
+        return self._op
+
+    @property
+    def properties(self):
+        return self._properties
+
+    @property
+    def time(self):
+        self._ensure_fetched()
+        return self._time
+
 
     def _fetch_ts_and_set_time(self, sparse: bool = None):
         """
@@ -47,9 +76,13 @@ class TimeSeries(abc.ABC):
         else:
             timestamps = (row[0] for row in res['items'])
 
-        self.time = np.array([self.source.client._parse_timestamp(t) for t in timestamps])
+        self._time = np.array([self.source.client._parse_timestamp(t) for t in timestamps])
 
         return res
+
+    def _ensure_fetched(self):
+        if self._time is None:
+            self._fetch()
 
     @abc.abstractmethod
     def _fetch(self):
@@ -143,8 +176,17 @@ class ScalarTimeSeries(TimeSeries):
     """
 
     def __init__(self, source, after, before, bucket, op, properties=None):
-        self.series = None
+        self._series = None
         super().__init__(source, after, before, bucket, op, properties)
+
+    @property
+    def series(self):
+        self._ensure_fetched()
+        return self._series
+
+    def _ensure_fetched(self):
+        if self._time is None or self._series is None:
+            self._fetch()
 
     def _fetch(self):
         api_response = self._fetch_ts_and_set_time()
@@ -158,7 +200,7 @@ class ScalarTimeSeries(TimeSeries):
         # Sparse representation is a list of dictionaries.  In each dictionary,
         # the fields are they keys.  We skip the first two fields
         # (time and footprint) which are handled elsewhere.
-        self.series = dict()
+        self._series = dict()
         for f in api_response['fields'][2:]:
             # extract the value for the field. If the value was None on the
             # server side, it was not sent -- so we cannot assume that the key
@@ -167,9 +209,9 @@ class ScalarTimeSeries(TimeSeries):
             # If all values are None, replace the array with a NoneArray;
             # else we store the data in a numpy array.
             if all(x is None for x in field_data):
-                self.series[f] = NoneArray(len(self))
+                self._series[f] = NoneArray(len(field_data))
             else:
-                self.series[f] = np.array(field_data)
+                self._series[f] = np.array(field_data)
 
     def _parse_dense_response(self, api_response):
         assert not api_response['sparse']
@@ -179,32 +221,53 @@ class ScalarTimeSeries(TimeSeries):
         else:
             transpose = [[]] * len(api_response['fields'])
 
-        self.series = dict()
+        self._series = dict()
         # iterate over fields, except for 'time' and 'footprint' (the first two)
         for idx in range(2, len(api_response['fields'])):
             field_name = api_response['fields'][idx]
             if all(x is None for x in transpose[idx]):
-                self.series[field_name] = NoneArray(len(transpose[idx))
+                self._series[field_name] = NoneArray(len(transpose[idx]))
             else:
-                self.series[field_name] = np.array(transpose[idx])
+                self._series[field_name] = np.array(transpose[idx])
 
     def get_item(self, args):
         assert len(args) == 1
         return (self.time[args], dict((propname, self.series[propname][args]) for propname in self.series))
 
+    def export(self, stream, data_format: str = 'csv') -> None:
+        if data_format != 'csv':
+            raise NotImplementedError("only CSV export is supported")
+        args = {'after': self.after, 'before': self.before,
+                'bucket': self.bucket, 'op': self.op}
+        if self.properties:
+            args['fields'] = ','.join(self.properties)
+        args['format'] = 'csv'
+
+        for chunk in self.source.client.export_timeseries(self.source.tdmq_id, args, data_format='csv'):
+            stream.write(chunk)
+
 
 class NonScalarTimeSeries(TimeSeries):
     def __init__(self, source, after, before, bucket, op):
-        self.tiledb_indices = None
+        self._tiledb_indices = None
         if bucket:
             raise NotImplementedError("Bucketing is not yet implemented in the client for non-scalar timeseries")
         super().__init__(source, after, before, bucket, op)
+
+    @property
+    def tiledb_indices(self):
+        self._ensure_fetched()
+        return self._tiledb_indices
+
+    def _ensure_fetched(self):
+        if self._time is None or self._tiledb_indices is None:
+            self._fetch()
 
     def _fetch(self):
         # NonScalarTimeSeries ignores any properties specified.  It only considers tiledb_index
         api_response = self._fetch_ts_and_set_time(sparse=False)
         assert api_response['fields'][2] == 'tiledb_index'
-        self.tiledb_indices = [row[2] for row in api_response['items']]
+        self._tiledb_indices = [row[2] for row in api_response['items']]
 
     def fetch_data_block(self, args):
         if self.bucket is None:

--- a/tdmq/client/timeseries.py
+++ b/tdmq/client/timeseries.py
@@ -44,7 +44,6 @@ class TimeSeries(abc.ABC):
         self._ensure_fetched()
         return self._time
 
-
     def _fetch_ts_and_set_time(self, sparse: bool = None):
         """
         Fetch timeseries from tdmq web service and set the self.time array; returns tdmq

--- a/tdmq/db.py
+++ b/tdmq/db.py
@@ -639,7 +639,7 @@ def get_timeseries_result(tdmq_id, batch_size: int = None, **kwargs):
         properties = ['tiledb_index']
     else:
         properties = description['controlledProperties']
-        if kwargs and kwargs.get('fields', []):
+        if kwargs.get('fields'):
             fields = kwargs['fields']
             # keep the order specified in fields
             properties = [f for f in fields if f in properties]
@@ -654,7 +654,7 @@ def get_timeseries_result(tdmq_id, batch_size: int = None, **kwargs):
         {where_clause}
         {grouping_clause}""")
 
-    if kwargs and kwargs.get('bucket'):
+    if kwargs.get('bucket'):
         bucket_interval = kwargs['bucket']
 
         if description.get('shape'):

--- a/tdmq/model.py
+++ b/tdmq/model.py
@@ -334,11 +334,12 @@ class Timeseries:
             return row_batch
 
     @classmethod
-    def get_one_by_batch(cls, tdmq_id: str, anonymize_private: bool = True, args: Dict[str, Any] = None) -> Generator[Dict[str, Any]]:
+    def get_one_by_batch(cls, tdmq_id: str, anonymize_private: bool = True,
+                         batch_size: int = None, args: Dict[str, Any] = None) -> Generator[Dict[str, Any]]:
         if not args:
             args = dict()
 
-        ts_result = db.get_timeseries_result(tdmq_id, **args)
+        ts_result = db.get_timeseries_result(tdmq_id, batch_size, **args)
 
         if args['bucket']:
             bucket = {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -623,7 +623,7 @@ def test_get_timeseries_properties_sparse(flask_client, db_data):
     source_id = 'tdm/sensor_1'
     response = flask_client.get(f'/sources?id={source_id}')
     tdmq_id = response.get_json()[0]['tdmq_id']
-    q = f'fields=temperature'
+    q = 'fields=temperature'
     response = flask_client.get(f'/sources/{tdmq_id}/timeseries?{q}')
     d = response.get_json()
     assert len(d['items']) == 4
@@ -638,7 +638,7 @@ def test_get_timeseries_properties_sparse_override(flask_client, db_data):
     source_id = 'tdm/sensor_1'
     response = flask_client.get(f'/sources?id={source_id}')
     tdmq_id = response.get_json()[0]['tdmq_id']
-    q = f'fields=temperature&sparse=false'
+    q = 'fields=temperature&sparse=false'
     response = flask_client.get(f'/sources/{tdmq_id}/timeseries?{q}')
     d = response.get_json()
     assert len(d['items']) == 4

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -582,6 +582,19 @@ def test_get_timeseries_empty_properties(flask_client, app, db_data):
 
 
 @pytest.mark.timeseries
+def test_get_timeseries_multibatch(flask_client, app, db_data):
+    source_id = 'tdm/sensor_1'
+    response = flask_client.get(f'/sources?id={source_id}')
+    tdmq_id = response.get_json()[0]['tdmq_id']
+    response = flask_client.get(f'/sources/{tdmq_id}/timeseries?batch_size=1')
+    assert response.is_streamed
+    d = response.get_json()
+    assert len(d['items']) == 4
+    assert d['sparse'] is True
+    assert isinstance(d['items'][0], dict)
+
+
+@pytest.mark.timeseries
 def test_get_timeseries_properties_sparse(flask_client, db_data):
     source_id = 'tdm/sensor_1'
     response = flask_client.get(f'/sources?id={source_id}')


### PR DESCRIPTION
Implements streaming download of timeseries and export from client as CSV.

The PR adds several features to how timeseries are extracted.
* Timeseries data is streamed in batches rather than as a single block.  This should make the service work better with large queries.  Batch size is configurable with a new API parameter.
* A sparse and a dense format for transmission of timeseries data are implemented.  Format is selectable through a new API parameter.  By default, heuristically the dense format is used if the user specifies the list of properties to extract, while the sparse format is used otherwise (not specifying properties results in the extract of all controlledProperties for the specific entity class, most of which are not actually measured by our devices).
* A new method in the client-side Timeseries class allows exporting the result of a query as a CSV.
* The client-side Timeseries class is now lazy-loading (this to support both numpy and CSV outputs).