### PR TITLE
Fix: allow including private sources on safe attribute value searches

### DIFF
--- a/tdmq/api.py
+++ b/tdmq/api.py
@@ -120,6 +120,7 @@ def sources_get():
         if only_public:
             rargs['public'] = True
     else:
+        # If neither 'public' nor 'only_public' have been specified, default to public=True
         rargs['public'] = rargs.get('public', True)
 
     if 'roi' in rargs:

--- a/tdmq/model.py
+++ b/tdmq/model.py
@@ -205,9 +205,6 @@ class Source:
         if not public and 'roi' in query_args:
             cls._quantize_roi(query_args['roi'])
 
-        if match_attr:
-            query_args.update(match_attr)
-
         # Generally, queries that container "unsafe" search keys will be limited to
         # private sources.  However, we allow querying private sources by specific
         # external source id.
@@ -215,6 +212,10 @@ class Source:
                 cls.SafeDescriptionKeys >= match_attr.keys()):
             # can't do query on private sources because it uses unsafe attributes
             query_args['public'] = True
+
+        if match_attr:
+            # Dump both "query" and "match" arguments into the same dict for the DB query
+            query_args.update(match_attr)
 
         raw = db.list_sources(query_args)
         for source in raw:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -351,6 +351,18 @@ def test_source_query_private_by_external_id(flask_client, db_data, source_data)
 
 
 @pytest.mark.sources
+def test_source_query_private_by_match_attr(flask_client, db_data):
+    response = flask_client.get(f'/sources?station_model=airRohr&public=false')
+    _checkresp(response)
+    array = response.get_json()
+    assert len(array) == 1
+    matched_source = array[0]
+    assert matched_source['external_id'] is None  # Would be'tdm/sensor_7', but it has been anonymized
+    assert matched_source['description']['station_model'] == 'airRohr'
+    assert matched_source['public'] is False
+
+
+@pytest.mark.sources
 def test_private_source_query_by_tdmq_id_unauthenticated(flask_client, db_data, source_data):
     from tdmq.db import _compute_tdmq_id
     private_source = next(s for s in source_data['sources'] if not s.get('public'))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -352,7 +352,7 @@ def test_source_query_private_by_external_id(flask_client, db_data, source_data)
 
 @pytest.mark.sources
 def test_source_query_private_by_match_attr(flask_client, db_data):
-    response = flask_client.get(f'/sources?station_model=airRohr&public=false')
+    response = flask_client.get('/sources?station_model=airRohr&public=false')
     _checkresp(response)
     array = response.get_json()
     assert len(array) == 1


### PR DESCRIPTION
Searching for sources by safe attributes (e.g., station_model=airRohr)
would automatically wrongly exclude all private sources.  This commit
fixes the problem and adds a test for it.