### PR TITLE
Lower default batch size to 2500 records

### DIFF
--- a/docker/web-entrypoint.sh
+++ b/docker/web-entrypoint.sh
@@ -33,5 +33,5 @@ if [[ "${DEV}" == "true" ]]; then
     export FLASK_RUN_HOST=0.0.0.0
     flask run "${@}"
 else
-    gunicorn -b 0.0.0.0:8000 "wsgi:get_wsgi_app()"
+    gunicorn -b 0.0.0.0:8000 --config "python:gunicorn.conf.py" "wsgi:get_wsgi_app()"
 fi

--- a/tdmq/api.py
+++ b/tdmq/api.py
@@ -207,11 +207,9 @@ def timeseries_get_stream(tdmq_id):
     if data_format not in ('json', 'csv'):
         raise wex.BadRequest(f"Unknown/unsupported format {data_format}")
 
-    batch_size = int(rargs.get('batch_size', -1))
-    if batch_size <= 0:
-        batch_size = None
-    else:
-        logger.debug("GET requested batch_size of %s", batch_size)
+    batch_size = int(rargs.get('batch_size', 2500))
+    assert batch_size > 0
+    logger.debug("GET using batch_size of %s", batch_size)
 
     result = Timeseries.get_one_by_batch(tdmq_id, anonymize_private, batch_size, args)
 

--- a/tdmq/db.py
+++ b/tdmq/db.py
@@ -84,9 +84,8 @@ def query_db_all(q, args=(), fetch=True, one=False, cursor_factory=None):
     return result
 
 
-def query_db_batches(q, args=(), batch_size: int = None, cursor_factory=None):
-    if batch_size is None:
-        batch_size = 10000
+def query_db_batches(q, args=(), batch_size: int = 2500, cursor_factory=None):
+    assert batch_size > 0
     logger.debug("executing batch query with batch_size %s", batch_size)
     with get_db() as db:
         with db.cursor(cursor_factory=cursor_factory) as cur:

--- a/tdmq/gunicorn.conf.py
+++ b/tdmq/gunicorn.conf.py
@@ -1,0 +1,9 @@
+
+# Gunicorn configuration
+
+# timeout
+# Default: 30
+# Workers silent for more than this many seconds are killed and restarted.
+#
+# Keep this higher than the query timeout on the pgsql connection
+timeout = 60


### PR DESCRIPTION
The previous default batch size (10000 records) results in timeouts.  Tested various batch sizes (1000, 2000, 3000, 5000).  Two-three thousand seems to be the sweet spot: smaller is slower overall; larger doesn't gain anything.