### PR TITLE
Set reorder policy on the record table to match (source_id, time) index

### DIFF
--- a/tdmq/tdmq_db_migrations/versions/cc88f3768771_apply_reorder_policy_on_record_table.py
+++ b/tdmq/tdmq_db_migrations/versions/cc88f3768771_apply_reorder_policy_on_record_table.py
@@ -1,0 +1,24 @@
+"""apply reorder policy on record table
+
+Revision ID: cc88f3768771
+Revises: 288cd4eb46af
+Create Date: 2021-11-22 17:02:52.414356
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'cc88f3768771'
+down_revision = '288cd4eb46af'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("SELECT add_reorder_policy('record', 'record_source_id_time_idx');")
+
+
+def downgrade():
+    op.execute("SELECT remove_reorder_policy('conditions', if_exists => true);")

--- a/tdmq/tdmq_db_migrations/versions/cc88f3768771_apply_reorder_policy_on_record_table.py
+++ b/tdmq/tdmq_db_migrations/versions/cc88f3768771_apply_reorder_policy_on_record_table.py
@@ -6,7 +6,6 @@ Create Date: 2021-11-22 17:02:52.414356
 
 """
 from alembic import op
-import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.


### PR DESCRIPTION
This change should result in increased performance of queries extracting longer timeseries for a source.