### PR TITLE
Configure application to run with multiple gunicorn workers.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,8 @@ run-tests: start
 	# to activate its HDFS client.
 	docker-compose -f docker/docker-compose.base.yml -f docker/docker-compose.testing.yml exec -T --user $$(id -u) tdmqc \
 		fake_user.sh /bin/bash -c 'for varname in $${!HADOOP*}; do unset $${varname}; done; cd $${TDMQ_DIST} && pytest -v tests -k "not hdfs"'
+	# Test metrics export
+	docker-compose -f docker/docker-compose.base.yml -f docker/docker-compose.testing.yml exec -T --user $$(id -u) tdmqc /bin/bash -c "wget -O - -q http://web:9100/"
 	docker-compose -f docker/docker-compose.base.yml -f docker/docker-compose.testing.yml exec -T tdmqj /bin/bash -c "python3 -c 'import tdmq, matplotlib'"
 	docker-compose -f docker/docker-compose.base.yml -f docker/docker-compose.testing.yml exec -T tdmqj /bin/bash -c 'python3 $${TDMQ_DIST}/tests/quickstart_dense.py -f s3://quickdense/quickstart_array --log-level DEBUG'
 	docker run --rm --net docker_tdmq --user $$(id -u) --env-file docker/settings.conf --env TDMQ_AUTH_TOKEN= tdmproject/tdmqc-conda /usr/local/bin/tdmqc_run_tests -k "not hdfs"

--- a/docker/docker-compose.base.yml
+++ b/docker/docker-compose.base.yml
@@ -27,6 +27,7 @@ services:
       - "timescaledb"
     ports:
       - "8000:8000"
+      - "9100"
     env_file: &env_file
       - settings.conf
     environment:

--- a/docker/prometheus.yml
+++ b/docker/prometheus.yml
@@ -13,7 +13,7 @@ scrape_configs:
 - job_name: tdmq
   static_configs:
   - targets:
-    - web:8000
+    - web:9100
 # alerting:
 #   alertmanagers:
 #   - kubernetes_sd_configs:

--- a/docker/tdmqc_run_tests
+++ b/docker/tdmqc_run_tests
@@ -3,4 +3,4 @@
 export PYTHONPATH="${TDMQ_DIST}"
 
 cd "${TDMQ_DIST}/tests/"
-fake_user.sh pytest "${@}"
+fake_user.sh pytest -k 'not hdfs' "${@}"

--- a/tdmq/app.py
+++ b/tdmq/app.py
@@ -116,7 +116,6 @@ def configure_prometheus_exporter(app, prom_registry=None):
         os.environ['DEBUG_METRICS'] = 'true'
 
     if not metrics_class:
-        from prometheus_flask_exporter import PrometheusMetrics
         metrics_class = PrometheusMetrics
 
     metrics = metrics_class.for_app_factory(defaults_prefix='tdmq', registry=prom_registry)

--- a/tdmq/gunicorn.conf.py
+++ b/tdmq/gunicorn.conf.py
@@ -1,9 +1,14 @@
 
 # Gunicorn configuration
 
-# timeout
-# Default: 30
-# Workers silent for more than this many seconds are killed and restarted.
-#
-# Keep this higher than the query timeout on the pgsql connection
-timeout = 60
+import os
+from prometheus_flask_exporter.multiprocess import GunicornPrometheusMetrics
+
+
+def when_ready(_):
+    metrics_port = int(os.environ.get('TDMQ_METRICS_PORT', 9100))
+    GunicornPrometheusMetrics.start_http_server_when_ready(metrics_port)
+
+
+def child_exit(_, worker):
+    GunicornPrometheusMetrics.mark_process_dead_on_child_exit(worker.pid)

--- a/tdmq/wsgi.py
+++ b/tdmq/wsgi.py
@@ -1,24 +1,18 @@
 
-from prometheus_client.exposition import make_wsgi_app
-
 from tdmq.app import create_app
 
 
 class PrefixMiddleware:
 
-    def __init__(self, app, prom_app, prefix='', prom_prefix='/metrics'):
+    def __init__(self, app, prefix=''):
         self.app = app
-        self.prom_app = prom_app
         self.prefix = prefix
-        self.prom_prefix = prom_prefix
 
     def __call__(self, environ, start_response):
         if environ['PATH_INFO'].startswith(self.prefix):
             environ['PATH_INFO'] = environ['PATH_INFO'][len(self.prefix):]
             environ['SCRIPT_NAME'] = self.prefix
             return self.app(environ, start_response)
-        if environ['PATH_INFO'].startswith(self.prom_prefix):
-            return self.prom_app(environ, start_response)
         # else:
         start_response('404', [('Content-Type', 'text/plain')])
         return ["This url does not belong to the app.".encode()]
@@ -26,8 +20,7 @@ class PrefixMiddleware:
 
 def get_wsgi_app():
     app = create_app()
-    prom_app = make_wsgi_app()
-    app.wsgi_app = PrefixMiddleware(app.wsgi_app, prom_app)
+    app.wsgi_app = PrefixMiddleware(app.wsgi_app)
     return app
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ import tempfile
 import time
 from collections import defaultdict
 
+import prometheus_client
 import pytest
 import geojson
 import shapely.geometry as sg
@@ -166,19 +167,19 @@ def public_db_data(clean_db, public_source_data):
 @pytest.fixture
 def app(db_connection_config, auth_token, local_zone_db):
     """Create and configure a new app instance for each test."""
-    app = create_app({
-        'TESTING': True,
-        'DB_HOST': db_connection_config['host'],
-        'DB_PORT': db_connection_config['port'],
-        'DB_NAME': db_connection_config['dbname'],
-        'DB_USER': db_connection_config['user'],
-        'DB_PASSWORD': db_connection_config['password'],
-        'LOG_LEVEL': 'DEBUG',
-        'PROMETHEUS_REGISTRY': True,
-        'APP_PREFIX': '',
-        'AUTH_TOKEN': auth_token,
-        'LOC_ANONYMIZER_DB': local_zone_db
-    })
+    app = create_app(
+        test_config={
+            'TESTING': True,
+            'DB_HOST': db_connection_config['host'],
+            'DB_PORT': db_connection_config['port'],
+            'DB_NAME': db_connection_config['dbname'],
+            'DB_USER': db_connection_config['user'],
+            'DB_PASSWORD': db_connection_config['password'],
+            'LOG_LEVEL': 'DEBUG',
+            'APP_PREFIX': '',
+            'AUTH_TOKEN': auth_token,
+            'LOC_ANONYMIZER_DB': local_zone_db },
+        prom_registry=prometheus_client.CollectorRegistry())
 
     app.testing = True
     try:
@@ -501,7 +502,6 @@ DB_NAME = "{db_connection_config['dbname']}"
 DB_USER = "{db_connection_config['user']}"
 DB_PASSWORD = "{db_connection_config['password']}"
 LOG_LEVEL = "DEBUG"
-PROMETHEUS_REGISTRY = True
 TILEDB_VFS_ROOT = "{service_info['tiledb']['storage.root']}"
 TILEDB_VFS_CONFIG = {service_info['tiledb']['config']}
 TILEDB_VFS_CREDENTIALS = {storage_credentials}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,7 +6,9 @@ import uuid
 from contextlib import contextmanager
 from datetime import datetime
 
+import prometheus_client
 import pytest
+
 from tdmq.app import create_app
 from tdmq.model import Source
 
@@ -19,9 +21,8 @@ def _create_new_app_test_client(config=None):
         config = config.copy()
         config['TESTING'] = True
         config['LOG_LEVEL'] = 'DEBUG'
-        config['PROMETHEUS_REGISTRY'] = True
 
-    app = create_app(config)
+    app = create_app(config, prom_registry=prometheus_client.CollectorRegistry())
     with app.app_context():
         yield app.test_client()
 

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,6 +1,9 @@
+
+import prometheus_client
+
 from tdmq.app import create_app
 
 
 def test_config():
-    assert not create_app({'PROMETHEUS_REGISTRY': True}).testing
-    assert create_app({'TESTING': True, 'PROMETHEUS_REGISTRY': True}).testing
+    assert not create_app(prom_registry=prometheus_client.CollectorRegistry()).testing
+    assert create_app({'TESTING': True}, prom_registry=prometheus_client.CollectorRegistry()).testing


### PR DESCRIPTION
Allowing multiple workers required modifying how the application exports
metrics for prometheus.  With this commit, they are exported from a
dedicated web app started by gunicorn, by default on port 9100.