### PR TITLE
Support access from outside k8s cluster

### DIFF
--- a/tdmq/api.py
+++ b/tdmq/api.py
@@ -76,11 +76,6 @@ def auth_required(f):
     return decorated_function
 
 
-@tdmq_bp.route('/')
-def index():
-    return 'The URL for this page is {}'.format(url_for('tdmq.index'))
-
-
 @tdmq_bp.route('/entity_types')
 def entity_types_get():
     types = EntityType.get_entity_types()
@@ -320,6 +315,7 @@ def records_post():
     return jsonify({"loaded": n})
 
 
+@tdmq_bp.route('/')
 @tdmq_bp.route('/service_info')
 def service_info_get():
     response = {

--- a/tdmq/errors.py
+++ b/tdmq/errors.py
@@ -29,38 +29,43 @@ class TdmqError(Exception):
 
 
 class TdmqBadRequestException(TdmqError):
-    def __init__(self, msg: str = None):
-        super().__init__("Bad Request", 400, msg)
-
-
-class QueryTooLargeException(TdmqError):
-    def __init__(self, msg: str = None):
-        super().__init__("Query Result Too Large", 413, msg)
+    def __init__(self, msg: str = None, status: int = 400):
+        super().__init__("Bad Request", status, msg)
 
 
 class DuplicateItemException(TdmqError):
-    def __init__(self, msg: str = None):
-        super().__init__("Duplicate entity", 400, msg)
+    def __init__(self, msg: str = None, status: int = 400):
+        super().__init__("Duplicate entity", status, msg)
 
 
 class ItemNotFoundException(TdmqError):
-    def __init__(self, msg: str = None):
-        super().__init__("Item not found", 404, msg)
+    def __init__(self, msg: str = None, status: int = 404):
+        super().__init__("Item not found", status, msg)
 
 
-class UnsupportedFunctionality(TdmqError):
-    def __init__(self, msg: str = None):
-        super().__init__("Unsupported functionality", 501, msg)
-
-
-class InternalServerError(TdmqError):
-    def __init__(self, msg: str = None):
-        super().__init__("Internal server error", 500, msg)
+class QueryTooLargeException(TdmqError):
+    def __init__(self, msg: str = None, status: int = 413):
+        super().__init__("Query Result Too Large", status, msg)
 
 
 class UnauthorizedError(TdmqError):
-    def __init__(self, msg: str = None):
-        super().__init__("Unauthorized", 403, msg)
+    def __init__(self, msg: str = None, status: int = 401):
+        super().__init__("Unauthorized", status, msg)
+
+
+class ForbiddenError(TdmqError):
+    def __init__(self, msg: str = None, status: int = 403):
+        super().__init__("Forbidden", status, msg)
+
+
+class InternalServerError(TdmqError):
+    def __init__(self, msg: str = None, status: int = 500):
+        super().__init__("Internal server error", status, msg)
+
+
+class UnsupportedFunctionality(TdmqError):
+    def __init__(self, msg: str = None, status: int = 501):
+        super().__init__("Unsupported functionality", status, msg)
 
 
 class DBOperationalError(InternalServerError):

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -3,7 +3,6 @@
 import pytest
 
 from pytest_mock import MockerFixture
-from requests.exceptions import HTTPError
 from tdmq.client import Client
 from tdmq.errors import UnauthorizedError
 
@@ -158,9 +157,9 @@ def test_get_anonymized_source(clean_storage, db_data, source_data, live_app):
     src = c.get_source(tdmq_id)
     assert src.alias is None
 
-    with pytest.raises(HTTPError) as exc_info:
+    with pytest.raises(UnauthorizedError) as exc_info:
         c.get_source(tdmq_id, anonymized=False)
-    assert exc_info.value.response.status_code == 401  # unauthorized
+    assert exc_info.value.status == 401  # unauthorized
 
 
 def test_imports():

--- a/tests/client/test_non_scalar_source.py
+++ b/tests/client/test_non_scalar_source.py
@@ -6,9 +6,9 @@ from datetime import datetime, timedelta, timezone
 
 import numpy as np
 import pytest
-from requests.exceptions import HTTPError
 from tdmq.client import Client
 from tdmq.client.sources import NonScalarSource
+from tdmq.errors import UnauthorizedError
 
 from test_source import is_scalar, register_sources
 
@@ -117,9 +117,9 @@ def test_nonscalar_source_register_deregister_as_admin(clean_storage, source_dat
 
 def test_nonscalar_source_register_as_user(clean_storage, source_data, live_app):
     c = Client(live_app.url())
-    with pytest.raises(HTTPError) as ve:
+    with pytest.raises(UnauthorizedError) as ve:
         register_nonscalar_sources(c, source_data)
-        assert ve.code == 401
+        assert ve.status == 401
 
 
 def test_nonscalar_source_deregister_as_user(clean_storage, source_data, live_app):
@@ -128,9 +128,9 @@ def test_nonscalar_source_deregister_as_user(clean_storage, source_data, live_ap
     srcs = register_nonscalar_sources(c, source_data)
 
     c = Client(live_app.url())
-    with pytest.raises(HTTPError) as ve:
+    with pytest.raises(UnauthorizedError) as ve:
         c.deregister_source(srcs[0])
-        assert ve.code == 401
+        assert ve.status == 401
 
 
 def test_nonscalar_source_access_as_user(clean_storage, source_data, live_app):

--- a/tests/client/test_records.py
+++ b/tests/client/test_records.py
@@ -4,8 +4,8 @@ from datetime import datetime, timedelta, timezone
 import numpy as np
 import pytest
 import pytz
-from requests.exceptions import HTTPError
 from tdmq.client import Client
+from tdmq.errors import UnauthorizedError
 
 from test_source import register_scalar_sources
 
@@ -48,10 +48,10 @@ def test_add_scalar_records_as_user(clean_storage, public_source_data, live_app)
     c = Client(live_app.url())
     by_source = public_source_data['records_by_source']
     for s in c.find_sources():
-        with pytest.raises(HTTPError) as ve:
+        with pytest.raises(UnauthorizedError) as ve:
             t = datetime.strptime(by_source[s.id][0]['time'], c.TDMQ_DT_FMT_NO_MICRO)
             s.ingest_one(t, by_source[s.id][0]['data'])
-            assert ve.code == 401
+            assert ve.status == 401
 
 
 def test_add_scalar_record_as_admin(clean_storage, public_source_data, live_app):
@@ -73,11 +73,11 @@ def test_add_scalar_record_as_user(clean_storage, public_source_data, live_app):
     c = Client(live_app.url())
     by_source = public_source_data['records_by_source']
     for s in c.find_sources():
-        with pytest.raises(HTTPError) as ve:
+        with pytest.raises(UnauthorizedError) as ve:
             for r in by_source[s.id]:
                 t = datetime.strptime(r['time'], c.TDMQ_DT_FMT_NO_MICRO)
                 s.ingest_one(t, r['data'])
-            assert ve.code == 401
+            assert ve.status == 401
 
 
 def test_ingest_scalar_record_as_admin(clean_storage, public_source_data, live_app):
@@ -107,9 +107,9 @@ def test_ingest_scalar_record_as_user(clean_storage, public_source_data, live_ap
             except ValueError:
                 t = datetime.strptime(r['time'], c.TDMQ_DT_FMT_NO_MICRO)
             data = r['data']
-            with pytest.raises(HTTPError) as ve:
+            with pytest.raises(UnauthorizedError) as ve:
                 s.ingest(t, data)
-                assert ve.code == 401
+                assert ve.status == 401
 
 
 def test_ingest_scalar_record_timezone(clean_storage, public_source_data, live_app):

--- a/tests/client/test_timeseries.py
+++ b/tests/client/test_timeseries.py
@@ -5,9 +5,9 @@ from datetime import datetime, timedelta, timezone
 
 import numpy as np
 import pytest
-import requests
 
 from tdmq.client import Client
+from tdmq.errors import UnauthorizedError
 
 pytestmark = pytest.mark.timeseries
 
@@ -129,9 +129,9 @@ def test_create_timeseries_range_as_user(clean_storage, clean_db, live_app):
     hums = [i / N for i in range(N)]
 
     for t, tv, th in zip(times, temps, hums):
-        with pytest.raises(requests.exceptions.HTTPError) as he:
+        with pytest.raises(UnauthorizedError) as he:
             s.ingest_one(t, {'temperature': tv, 'humidity': th})
-            assert he.status_code == '401'
+            assert he.status == '401'
 
 
 def test_check_timeseries_range_as_user(clean_storage, clean_db, live_app):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -178,7 +178,9 @@ def app(db_connection_config, auth_token, local_zone_db):
             'LOG_LEVEL': 'DEBUG',
             'APP_PREFIX': '',
             'AUTH_TOKEN': auth_token,
-            'LOC_ANONYMIZER_DB': local_zone_db },
+            'LOC_ANONYMIZER_DB': local_zone_db,
+            'EXTERNAL_HOST_DOMAIN': 'jicsardegna.it',
+        },
         prom_registry=prometheus_client.CollectorRegistry())
 
     app.testing = True
@@ -502,9 +504,12 @@ DB_NAME = "{db_connection_config['dbname']}"
 DB_USER = "{db_connection_config['user']}"
 DB_PASSWORD = "{db_connection_config['password']}"
 LOG_LEVEL = "DEBUG"
-TILEDB_VFS_ROOT = "{service_info['tiledb']['storage.root']}"
-TILEDB_VFS_CONFIG = {service_info['tiledb']['config']}
-TILEDB_VFS_CREDENTIALS = {storage_credentials}
+EXTERNAL_HOST_DOMAIN = None
+TILEDB_INTERNAL_VFS = {{
+    'storage.root': "{service_info['tiledb']['storage.root']}",
+    'config': {service_info['tiledb']['config']},
+    'credentials': {storage_credentials}
+}}
 APP_PREFIX = ''
 AUTH_TOKEN = '{auth_token}'
 LOC_ANONYMIZER_DB = '{local_zone_db}'

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -472,6 +472,7 @@ def test_source_get_latest_activity_not_found(flask_client, public_db_data):
     assert response.status_code == 404
 
 
+@pytest.mark.sources
 def test_source_get_ensure_safe_attributes(flask_client, public_db_data):
     source_id = 'tdm/tiledb_sensor_6'
     response = flask_client.get(f'/sources?id={source_id}')
@@ -886,7 +887,7 @@ def test_get_private_timeseries_authenticated_unanonymized(flask_client, clean_d
 
 
 @pytest.mark.sources
-def test_search_for_private_sources(flask_client, app, db_data):
+def test_search_for_private_sources(flask_client, db_data):
     source_id = 'tdm/sensor_7'
     response = flask_client.get(f'/sources?id={source_id}')
     _checkresp(response)
@@ -894,7 +895,7 @@ def test_search_for_private_sources(flask_client, app, db_data):
 
 
 @pytest.mark.sources
-def test_search_sources_by_attr(flask_client, app, db_data, public_source_data):
+def test_search_sources_by_attr(flask_client, db_data, public_source_data):
     external_id = "tdm/sensor_3"
     source = next(s for s in public_source_data['sources']
                   if s.get('id') == external_id)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -966,14 +966,16 @@ def test_get_service_info_authenticated(flask_client):
                             headers=_create_auth_header(flask_client.auth_token))
     _checkresp(resp)
     info = resp.json
-    assert info.get('version') is not None
+    assert 'version' in info
     assert re.fullmatch(r'(\d+\.){1,2}\d+', info['version'])
+    assert info['version'] == '0.1'
+    assert info['client-origin'] == 'internal'
     assert 'tiledb' in info
     assert 'vfs.s3.aws_access_key_id' in info['tiledb']['config']
     assert 'vfs.s3.aws_secret_access_key' in info['tiledb']['config']
+
     # Request again without authentication
     resp = flask_client.get('/service_info')
-    _checkresp(resp)
     info = resp.json
     assert 'tiledb' in info
     assert 'vfs.s3.aws_access_key_id' not in info['tiledb']['config']
@@ -981,13 +983,55 @@ def test_get_service_info_authenticated(flask_client):
 
 
 @pytest.mark.config
-def test_app_config_tiledb(local_zone_db):
+def test_check_config_validation():
+    config = {
+        # missing mandatory key storage.root
+        'TILEDB_INTERNAL_VFS': {}
+    }
+    with pytest.raises(ValueError):
+        with _create_new_app_test_client(config):
+            pass
+
+    config = {
+        # missing mandatory key storage.root
+        'TILEDB_EXTERNAL_VFS': {}
+    }
+    with pytest.raises(ValueError):
+        with _create_new_app_test_client(config):
+            pass
+
+    config = {
+        'TILEDB_INTERNAL_VFS': {
+            'storage.root': 'my-place',
+            'some illegal key': 'string'
+        }
+    }
+    with pytest.raises(ValueError):
+        with _create_new_app_test_client(config):
+            pass
+
+    config = {
+        'TILEDB_INTERNAL_VFS': {
+            'storage.root': 'my-place',
+        },
+        # obsolete key
+        'TILEDB_VFS_ROOT': 'my-place'
+    }
+    with pytest.raises(ValueError):
+        with _create_new_app_test_client(config):
+            pass
+
+
+@pytest.mark.config
+def test_app_config_tiledb():
     hdfs_root = 'hdfs://someserver:8020/'
     k, v = 'vfs.hdfs.property', 'pippo'
     config = {
-        'TILEDB_VFS_ROOT': hdfs_root,
-        'TILEDB_VFS_CONFIG': {k: v},
-        'APP_PREFIX': '',
+        'TILEDB_INTERNAL_VFS': {
+            'storage.root': hdfs_root,
+            'config': {k: v}
+        },
+        'APP_PREFIX': ''
     }
 
     with _create_new_app_test_client(config) as client:
@@ -1000,9 +1044,9 @@ def test_app_config_tiledb(local_zone_db):
 
 
 @pytest.mark.config
-def test_app_config_no_tiledb(local_zone_db):
+def test_app_config_no_tiledb():
     config = {
-        'TILEDB_VFS_ROOT': None,
+        'TILEDB_INTERNAL_VFS': None,
         'APP_PREFIX': '',
     }
 
@@ -1014,24 +1058,41 @@ def test_app_config_no_tiledb(local_zone_db):
 
 
 @pytest.mark.config
-def test_app_config_from_file(local_zone_db, monkeypatch):
+def test_app_config_from_file(monkeypatch):
     vfs_root = 's3://mybucket/'
-    cfg = f"TILEDB_VFS_ROOT = '{vfs_root}'\n" \
-        "TILEDB_VFS_CONFIG = { 'vfs.s3.property': 'bla' }\n" \
-        "APP_PREFIX = ''\n"
-
+    cfg = f"""
+TILEDB_INTERNAL_VFS = {{
+    'storage.root': '{vfs_root}',
+    'config': {{ 'vfs.s3.property': 'internal' }}
+}}
+TILEDB_EXTERNAL_VFS = {{
+    'storage.root': '{vfs_root}',
+    'config': {{ 'vfs.s3.property': 'external' }}
+}}
+EXTERNAL_HOST_DOMAIN = 'jicsardegna.it'
+APP_PREFIX = ''
+"""
     with tempfile.NamedTemporaryFile(mode='w') as f:
         f.write(cfg)
         f.flush()
 
         monkeypatch.setenv('TDMQ_FLASK_CONFIG', f.name)
         with _create_new_app_test_client() as client:
+            # Check reply without setting Host header
             resp = client.get('/service_info')
             _checkresp(resp)
             info = resp.json
             assert 'tiledb' in info
             assert info['tiledb']['storage.root'] == vfs_root
-            assert info['tiledb']['config']['vfs.s3.property'] == 'bla'
+            assert info['tiledb']['config']['vfs.s3.property'] == 'internal'
+
+            resp = client.get('/service_info', headers={'Host': 'my-internal-domain.cluster'})
+            info = resp.json
+            assert info['tiledb']['config']['vfs.s3.property'] == 'internal'
+
+            resp = client.get('/service_info', headers={'Host': 'tdmq.jicsardegna.it'})
+            info = resp.json
+            assert info['tiledb']['config']['vfs.s3.property'] == 'external'
 
 
 def test_convert_roi():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -933,6 +933,16 @@ def test_entity_categories_method_not_allowed(flask_client):
 
 
 @pytest.mark.config
+def test_get_index(flask_client):
+    resp = flask_client.get('/')
+    _checkresp(resp)
+    info = resp.json
+    # assert that the response looks like /service_info
+    assert info.get('version') is not None
+    assert re.fullmatch(r'(\d+\.){1,2}\d+', info['version'])
+
+
+@pytest.mark.config
 def test_get_service_info(flask_client):
     resp = flask_client.get('/service_info')
     _checkresp(resp)


### PR DESCRIPTION
This PR changes the client configuration served by tdmq depending on whether the client's request originates from inside or outside the internal network.